### PR TITLE
Added warden mock script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "mocha --require ./test/init",
     "lint": "eslint bin/** lib/** test/**",
     "coverage": "istanbul cover _mocha -- -R spec --require ./test/init",
-    "report-coverage": "npm run coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
+    "report-coverage": "npm run coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
+    "warden-mock": "node ./test/bin/warden.js"
   },
   "repository": {
     "type": "git",

--- a/test/bin/warden.js
+++ b/test/bin/warden.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const express = require('express');
+const bodyParser = require('body-parser');
+const Vaulted = require('vaulted');
+
+const DEFAULT_PORT = 3000;
+const VAULT_PORT = 8200;
+const token = process.argv[2];
+
+const app = express();
+const router = express.Router();
+const vault = new Vaulted({
+  vault_host: '127.0.0.1',
+  vault_port: VAULT_PORT,
+  vault_ssl: false
+});
+
+app.use(bodyParser.json());
+app.use(router);
+
+vault.setToken(token).prepare();
+
+router.param('id', (req, res, next, id) => {
+  req.id = id;
+  next();
+});
+
+router.route('/').post((req, res) => {
+  vault.createToken({
+    body: {
+      ttl: '1m'
+    }
+  })
+  .then((data) => {
+    const resp = {
+      lease_duration: data.auth.lease_duration,
+      renewable: data.auth.renewable,
+      data: {
+        token: data.auth.client_token
+      }
+    };
+
+    console.log(resp);
+    res.json(resp);
+  })
+  .catch((err) => {
+    console.log(err);
+    res.status(err.statusCode)
+        .json(err.error);
+  });
+});
+
+router.route('/mounts').get((req, res) => {
+  vault.getMounts()
+    .then((mounts) => res.json(mounts))
+    .catch((err) => res.status(err.statusCode).json(err.error))
+});
+
+router.route('/auths').get((req, res) => {
+  vault.getAuthMounts()
+    .then((authMounts) => res.json(authMounts))
+    .catch((err) => res.status(err.statusCode).json(err.error))
+});
+
+router.route('/secret/:id').get((req, res) => {
+  vault.read({
+    id: req.id
+  }).then((secret) => {
+    res.status(res.statusCode).json(secret);
+  });
+});
+
+app.listen(DEFAULT_PORT, () => {
+  console.log(`Listening on ${DEFAULT_PORT}`);
+});


### PR DESCRIPTION
This PR adds a developer tool that mocks Warden to simulate the entire propsd workflow.

Usage is as follows:

``` bash
$ vault server -dev-root-token-id="<SOME_TOKEN>" -dev
$ npm run warden-mock -- <SOME_TOKEN>
```

Keep in mind that EC2 metadata must be present (in some form) as the tokend `TokenProvider` relies on it explicitly to craft the payload to send to Warden even though this script doesn't care what you send it.
