### PR TITLE
Surface Errors on timeout

### DIFF
--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -18,6 +18,7 @@ class LeaseManager extends EventEmitter {
     this.data = null;
     this.lease_duration = 0;
     this.provider = provider;
+    this.error = null;
   }
 
   /**
@@ -54,6 +55,10 @@ class LeaseManager extends EventEmitter {
       this.status = 'PENDING';
       this.data = null;
       this.lease_duration = 0;
+      if (this.listeners('error').length > 0) {
+        this.emit('error', error);
+      }
+      this.error = error;
       this.initialize();
     }
     else {
@@ -61,6 +66,7 @@ class LeaseManager extends EventEmitter {
       this.data = result.data;
       this.lease_duration = result.lease_duration;
       this.emit('ready');
+      this.error = null;
       this._renew();
     }
   }

--- a/lib/utils/once-with-timeout.js
+++ b/lib/utils/once-with-timeout.js
@@ -32,16 +32,20 @@ module.exports = function onceWithTimeout(emitter, eventName, timeout) {
     const handler = function() {
       clearTimeout(timer);
       resolve(arguments);
-    }
+    };
 
     // If a timeout is specified, register a timer to timeout the event handler
     if (!isNaN(timeout) && timeout > 0 && timeout < Infinity) {
       timer = setTimeout(() => {
         emitter.removeListener(eventName, handler);
-        reject(new Error(`timeout: '${eventName}' event`));
+        if (emitter.error) {
+          reject(emitter.error);
+        } else {
+          reject(new Error(`timeout: '${eventName}' event`));
+        }
       }, timeout);
     }
 
     emitter.once(eventName, handler);
   });
-}
+};


### PR DESCRIPTION
This PR fixes a bug where only the generic error is surfaced when a queued request times out. Now when the queued request times out we see if an error has been set on the emitter and reject that. Otherwise we reject a generic error.
