### PR TITLE
Feature: Set token lease duration in config

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -2,7 +2,8 @@
   "vault": {
     "host": "127.0.0.1",
     "port": 8200,
-    "tls": true
+    "tls": true,
+    "token_ttl": "1m"
   },
   "metadata": {
     "host": "169.254.169.254"

--- a/lib/providers/token.js
+++ b/lib/providers/token.js
@@ -24,6 +24,8 @@ const DEFAULT_METADATA_HOST = Config.get('metadata:host');
 const DEFAULT_WARDEN_HOST = Config.get('warden:host');
 const DEFAULT_WARDEN_PORT = Config.get('warden:port');
 
+const VAULT_TOKEN_TTL = Config.get('vault:token_ttl');
+
 class TokenProvider {
   /**
    * Constructor
@@ -136,7 +138,11 @@ class TokenProvider {
     }
 
     this._client.prepare(this.token)
-      .then(this._client.renewToken.bind(this._client, {id: this.token, token: this.token}, null))
+      .then(this._client.renewToken.bind(this._client, {
+        id: this.token,
+        token: this.token,
+        body: {increment: VAULT_TOKEN_TTL}
+      }, null))
       .then((data) => {
         callback(null, {
           lease_duration: data.auth.lease_duration,


### PR DESCRIPTION
Added ability to set requested token lease duration via config. Default is 60 seconds.
