### PR TITLE
Fix: No TTL for Generic provider

### DIFF
--- a/lib/providers/generic.js
+++ b/lib/providers/generic.js
@@ -34,8 +34,6 @@ class GenericProvider {
     this.token = token;
 
     this._client = new Vaulted(VAULT_CONFIG);
-    this._ttl = null;
-    this._retrieved = null;
     this._value = null;
   }
 
@@ -52,8 +50,11 @@ class GenericProvider {
       return;
     }
 
-    this._client.prepare(this.token)
-      .then(this._client.read.bind(this._client, {id: this.path, token: this.token}, null))
+    this._client.prepare(this.token).then(() => this._retrieve(callback));
+  }
+
+  _retrieve(callback) {
+    return this._client.read({id: this.path, token: this.token})
       .then(this._read.bind(this, callback))
       .catch((err) => callback(err, null));
   }
@@ -61,53 +62,27 @@ class GenericProvider {
   /**
    * Renew the generic secret.
    *
-   * The method name is a misnomer in the sense that it does not actually renew the secret. Instead, it determines
-   * whether the secret is still considered valid (measured by the TTL expiration) and attempts to retrieve the
-   * secret again if so.
+   * The method name is effectively the same as initializing the secret.
    *
    * The callback has the following signature: `callback(err, data)`.
    *
    * @param {function} callback
    */
   renew(callback) {
-    if (!this._canReRead()) {
-      callback(null, this._value);
-      return;
-    }
-
-    this._client.read({id: this.path, token: this.token})
-      .then(this._read.bind(this, callback))
-      .catch((err) => {
-        callback(err, null);
-      });
+    this._retrieve(callback);
   }
 
   /**
-   * Processes a `Vaulted.read` response.
+   * Processes a `Vaulted.read/readCubby` response.
    *
    * @param {function} callback
    * @param {object} response
    * @private
    */
   _read(callback, response) {
-    // lease_duration is returned in seconds
-    this._ttl = (response.lease_duration * 1000);
-    this._retrieved = Date.now();
     this._value = response;
 
     callback(null, response);
-  }
-
-  /**
-   * Determines whether the secret has become invalid due to its TTL expiring.
-   *
-   * Returns `true` if the secret's TTL has expired.
-   *
-   * @returns {boolean}
-   * @private
-   */
-  _canReRead() {
-    return Date.now() >= (this._retrieved + this._ttl);
   }
 }
 

--- a/test/provider-generic.js
+++ b/test/provider-generic.js
@@ -87,48 +87,22 @@ describe('Provider/Generic', function () {
         .catch((err) => done(err));
     });
 
-    it('executes the callback with the cached secret if the secret TTL has not expired', function (done) {
+    it('attempts to re-read the secret when renewed', function (done) {
       const expectedResponse = Object.assign({
-        data: {value: 'coolvalue'},
-        lease_duration: 2592000
-      }, resp);
-
-      scope.get('/v1/secret/coolsecret').reply(STATUS_CODES.OK, expectedResponse);
-
-      const g = new GenericProvider('coolsecret', 'a-valid-token');
-      const cachedSecret = {value: 'coolvalue'};
-
-      return promisify((d) => g.initialize(d))
-        .then((data) => {
-          return data.should.eql(expectedResponse);
-        })
-        .then(g.renew.bind(g, ((err, data) => {
-          return data.should.eql(expectedResponse);
-        })))
-        .then(() => done())
-        .catch((err) => done(err));
-    });
-
-    it('attempts to re-read the secret if the secret TTL has expired', function (done) {
-      const expectedResponse1 = Object.assign({
-        data: {value: 'coolvalue'},
-        lease_duration: 0
-      }, resp);
-      const expectedResponse2 = Object.assign({
         data: {value: 'coolvalue2'},
         lease_duration: 2592000
       }, resp);
 
-      scope.get('/v1/secret/coolsecret').reply(STATUS_CODES.OK, expectedResponse1)
-        .get('/v1/secret/coolsecret').reply(STATUS_CODES.OK, expectedResponse2);
+      scope.get('/v1/secret/coolsecret').reply(STATUS_CODES.OK, expectedResponse)
+        .get('/v1/secret/coolsecret').reply(STATUS_CODES.OK, expectedResponse);
 
       const g = new GenericProvider('coolsecret', 'a-valid-token');
 
       return promisify((d) => g.initialize(d))
-          .then((data) => data.should.eql(expectedResponse1))
+          .then((data) => data.should.eql(expectedResponse))
           .then(() => g.renew(((err, data) => {
             should(err).equal(null);
-            data.should.eql(expectedResponse2);
+            data.should.eql(expectedResponse);
           })))
           .then(done)
           .catch((err) => done(err));


### PR DESCRIPTION
Deprecated ttl testing for generic secrets because 'renew'ing one of them is a misnomer. A secret expiring only means that vault guarantees the existence of that secret insofar as no one has deleted it from the backend. All initialize and renew calls should just request the secret again.
