### PR TITLE
Refactor with Promises

### DIFF
--- a/lib/control/util/index.js
+++ b/lib/control/util/index.js
@@ -11,6 +11,12 @@ const Handlers = {
   }
 };
 
+const Err = (err, req, res, next) => {
+  res.status(500);
+  res.json({error: err.message});
+};
+
 module.exports = {
-  Handlers
+  Handlers,
+  Err
 };

--- a/lib/control/v1/credential.js
+++ b/lib/control/v1/credential.js
@@ -8,11 +8,9 @@ function Credential(storage) {
     const mount = req.params.mount;
     const role = req.params.role;
 
-    storage.lookup(token, `${mount}/${role}`, CredentialProvider, (err, result) => {
-      const response = (err) ? {error: err.message} : result;
-
-      res.json(response);
-    });
+    storage.lookup(token, `${mount}/${role}`, CredentialProvider)
+      .then((result) => res.json(result))
+      .catch((err) => res.json({error: err.message}));
   };
 }
 

--- a/lib/control/v1/credential.js
+++ b/lib/control/v1/credential.js
@@ -3,14 +3,15 @@
 const CredentialProvider = require('../../providers/credential');
 
 function Credential(storage) {
-  return (req, res) => {
+  return (req, res, next) => {
     const token = req.params.token;
     const mount = req.params.mount;
     const role = req.params.role;
 
     storage.lookup(token, `${mount}/${role}`, CredentialProvider)
-      .then((result) => res.json(result))
-      .catch((err) => res.json({error: err.message}));
+      .then((result) => {
+        res.json(result)
+      }).catch(next);
   };
 }
 

--- a/lib/control/v1/cubbyhole.js
+++ b/lib/control/v1/cubbyhole.js
@@ -7,11 +7,9 @@ function CubbyHole(storage) {
     const token = req.params.token;
     const path = req.params.path;
 
-    storage.lookup(token, path, CubbyHoleProvider, (err, result) => {
-      const response = (err) ? {error: err.message} : result;
-
-      res.json(response);
-    });
+    storage.lookup(token, path, CubbyHoleProvider)
+      .then((result) => res.json(result))
+      .catch((err) => res.json({error: err.message}));
   };
 }
 

--- a/lib/control/v1/cubbyhole.js
+++ b/lib/control/v1/cubbyhole.js
@@ -3,13 +3,14 @@
 const CubbyHoleProvider = require('../../providers/cubbyhole');
 
 function CubbyHole(storage) {
-  return (req, res) => {
+  return (req, res, next) => {
     const token = req.params.token;
     const path = req.params.path;
 
     storage.lookup(token, path, CubbyHoleProvider)
-      .then((result) => res.json(result))
-      .catch((err) => res.json({error: err.message}));
+      .then((result) => {
+        res.json(result)
+      }).catch(next);
   };
 }
 

--- a/lib/control/v1/index.js
+++ b/lib/control/v1/index.js
@@ -2,6 +2,7 @@
 
 const express = require('express');
 const Handlers = require('../util').Handlers;
+const Err = require('../util').Err;
 
 exports.attach = function (app, storage) {
   app.get('/v1/health', require('./health'));
@@ -13,4 +14,5 @@ exports.attach = function (app, storage) {
   app.get('/v1/credential/:token/:mount/:role', require('./credential')(storage));
 
   app.use(Handlers.allowed('GET'));
+  app.use(Err);
 };

--- a/lib/control/v1/secret.js
+++ b/lib/control/v1/secret.js
@@ -7,11 +7,9 @@ function Secret(storage) {
     const token = req.params.token;
     const path = req.params.path;
 
-    storage.lookup(token, path, SecretProvider, (err, result) => {
-      const response = (err) ? {error: err.message} : result;
-
-      res.json(response);
-    });
+    storage.lookup(token, path, SecretProvider)
+      .then((result) => res.json(result))
+      .catch((err) => res.json({error: err.message}));
   };
 }
 

--- a/lib/control/v1/secret.js
+++ b/lib/control/v1/secret.js
@@ -3,13 +3,14 @@
 const SecretProvider = require('../../providers/secret');
 
 function Secret(storage) {
-  return (req, res) => {
+  return (req, res, next) => {
     const token = req.params.token;
     const path = req.params.path;
 
     storage.lookup(token, path, SecretProvider)
-      .then((result) => res.json(result))
-      .catch((err) => res.json({error: err.message}));
+      .then((result) => {
+        res.json(result)
+      }).catch(next);
   };
 }
 

--- a/lib/control/v1/token.js
+++ b/lib/control/v1/token.js
@@ -3,10 +3,11 @@
 const TokenProvider = require('../../providers/token');
 
 function Token(storage) {
-  return (req, res) => {
+  return (req, res, next) => {
     storage.lookup('default', 'default', TokenProvider)
-      .then((result) => res.json(result))
-      .catch((err) => res.json({error: err.message}));
+      .then((result) => {
+        res.json(result);
+      }).catch(next);
   };
 }
 

--- a/lib/control/v1/token.js
+++ b/lib/control/v1/token.js
@@ -4,11 +4,9 @@ const TokenProvider = require('../../providers/token');
 
 function Token(storage) {
   return (req, res) => {
-    storage.lookup('default', 'default', TokenProvider, (err, result) => {
-      const response = (err) ? {error: err.message} : result;
-
-      res.json(response);
-    });
+    storage.lookup('default', 'default', TokenProvider)
+      .then((result) => res.json(result))
+      .catch((err) => res.json({error: err.message}));
   };
 }
 

--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -27,27 +27,27 @@ class LeaseManager extends EventEmitter {
    * @returns {Promise}
    */
   initialize() {
-    return new Promise((resolve, reject) => {
-      this.provider.initialize().then((result) => {
-        this.status = STATUS.READY;
-        this.data = result.data;
-        this.lease_duration = result.lease_duration;
-        this.emit('ready');
-        this.error = null;
-        return resolve(this._renew());
-      }).catch((err) => {
-        this.status = STATUS.PENDING;
-        this.data = null;
-        this.lease_duration = 0;
-        if (this.listeners('error').length > 0) {
-          this.emit('error', err);
-        }
-        this.error = err;
+    return this.provider.initialize().then((result) => {
+      this.status = STATUS.READY;
+      this.data = result.data;
+      this.lease_duration = result.lease_duration;
+      this.emit('ready');
+      this.error = null;
+      this._renew();
+      return Promise.resolve(this);
+    }).catch((err) => {
+      this.status = STATUS.PENDING;
+      this.data = null;
+      this.lease_duration = 0;
+      if (this.listeners('error').length > 0) {
+        this.emit('error', err);
+      }
+      this.error = err;
 
-        // TODO: This isn't great. Ideally we should be rejecting error conditions and
-        // then handling any attempts at fixing the problem elsewhere.
-        return resolve(this.initialize());
-      });
+      // TODO: This isn't great. We need a combination of exponential backoff and having re-initialization on
+      // correction of the error condition occur elsewhere.
+      // return this.initialize();
+      return Promise.reject(err);
     });
   }
 
@@ -65,6 +65,7 @@ class LeaseManager extends EventEmitter {
         this.emit('renewed');
         this._renew();
       }).catch((err) => {
+        this.error = err;
         this.status = STATUS.PENDING;
         this.lease_duration = 0;
         this.initialize();

--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -24,6 +24,9 @@ class LeaseManager extends EventEmitter {
 
   /**
    * Initialize the SecretProvider
+   *
+   * TODO: Make this method way less problematic
+   *
    * @returns {Promise}
    */
   initialize() {

--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -24,10 +24,30 @@ class LeaseManager extends EventEmitter {
 
   /**
    * Initialize the SecretProvider
+   * @returns {Promise}
    */
   initialize() {
-    this.provider.initialize((error, result) => {
-      this._onProviderInitialize(error, result);
+    return new Promise((resolve, reject) => {
+      this.provider.initialize().then((result) => {
+        this.status = STATUS.READY;
+        this.data = result.data;
+        this.lease_duration = result.lease_duration;
+        this.emit('ready');
+        this.error = null;
+        return resolve(this._renew());
+      }).catch((err) => {
+        this.status = STATUS.PENDING;
+        this.data = null;
+        this.lease_duration = 0;
+        if (this.listeners('error').length > 0) {
+          this.emit('error', err);
+        }
+        this.error = err;
+
+        // TODO: This isn't great. Ideally we should be rejecting error conditions and
+        // then handling any attempts at fixing the problem elsewhere.
+        return resolve(this.initialize());
+      });
     });
   }
 
@@ -39,58 +59,18 @@ class LeaseManager extends EventEmitter {
     const timeout = (this.lease_duration / 2) * 1000; // eslint-disable-line rapid7/static-magic-numbers
 
     setTimeout(() => {
-      this.provider.renew((error, result) => {
-        this._onProviderRenew(error, result);
+      this.provider.renew().then((result) => {
+        this.lease_duration = result.lease_duration;
+        this.data = result.data;
+        this.emit('renewed');
+        this._renew();
+      }).catch((err) => {
+        this.status = STATUS.PENDING;
+        this.lease_duration = 0;
+        this.initialize();
       });
     }, timeout);
   }
-
-  /**
-   * Called when the SecretProvider finishes initializing
-   * @param {Error} error
-   * @param {Object} result
-   * @private
-   */
-  _onProviderInitialize(error, result) {
-    if (error) {
-      this.status = STATUS.PENDING;
-      this.data = null;
-      this.lease_duration = 0;
-      if (this.listeners('error').length > 0) {
-        this.emit('error', error);
-      }
-      this.error = error;
-      this.initialize();
-    }
-    else {
-      this.status = STATUS.READY;
-      this.data = result.data;
-      this.lease_duration = result.lease_duration;
-      this.emit('ready');
-      this.error = null;
-      this._renew();
-    }
-  }
-
-  /**
-   * Called when the SecretProvider finishes renewing the lease
-   * @param {Error} error
-   * @param {Object} result
-   * @private
-   */
-  _onProviderRenew(error, result) {
-    if (error) {
-      this.status = STATUS.PENDING;
-      this.lease_duration = 0;
-      this.initialize();
-    }
-    else {
-      this.lease_duration = result.lease_duration;
-      this.data = result.data;
-      this.emit('renewed');
-      this._renew();
-    }
-  }
-};
+}
 
 module.exports = LeaseManager;

--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const EventEmitter = require('events').EventEmitter;
+const STATUS = require('./utils/status');
 
 /**
  * The LeaseManager maintains state about a token or secret. It leverages a
@@ -14,7 +15,7 @@ class LeaseManager extends EventEmitter {
   constructor(provider) {
     super();
 
-    this.status = 'PENDING';
+    this.status = STATUS.PENDING;
     this.data = null;
     this.lease_duration = 0;
     this.provider = provider;
@@ -52,7 +53,7 @@ class LeaseManager extends EventEmitter {
    */
   _onProviderInitialize(error, result) {
     if (error) {
-      this.status = 'PENDING';
+      this.status = STATUS.PENDING;
       this.data = null;
       this.lease_duration = 0;
       if (this.listeners('error').length > 0) {
@@ -62,7 +63,7 @@ class LeaseManager extends EventEmitter {
       this.initialize();
     }
     else {
-      this.status = 'READY';
+      this.status = STATUS.READY;
       this.data = result.data;
       this.lease_duration = result.lease_duration;
       this.emit('ready');
@@ -79,7 +80,7 @@ class LeaseManager extends EventEmitter {
    */
   _onProviderRenew(error, result) {
     if (error) {
-      this.status = 'PENDING';
+      this.status = STATUS.PENDING;
       this.lease_duration = 0;
       this.initialize();
     }

--- a/lib/providers/credential.js
+++ b/lib/providers/credential.js
@@ -12,18 +12,18 @@ class CredentialProvider {
 
   /**
    * Initialize the credentials
-   * @param {function} callback
+   * @returns {Promise}
    */
-  initialize(callback) {
-    callback(null, true);
+  initialize() {
+    return Promise.resolve(true);
   }
 
   /**
    * Renew the credentials
-   * @param {function} callback
+   * @returns {Promise}
    */
-  renew(callback) {
-    callback(null, true);
+  renew() {
+    return Promise.resolve(true);
   }
 }
 

--- a/lib/providers/generic.js
+++ b/lib/providers/generic.js
@@ -40,51 +40,50 @@ class GenericProvider {
   }
 
   /**
-   * Retrieve the generic secret.
-   *
-   * The callback has the following signature: `callback(err, data)`.
-   *
-   * @param {function} callback
+   * Retrieve the secret.
+   * @returns {Promise}
    */
-  initialize(callback) {
-    if (this._value) {
-      callback(new Error('Already initialized'), null);
-      return;
-    }
+  initialize() {
+    return new Promise((resolve, reject) => {
+      if (this._value) {
+        reject(new Error('Already initialized'));
+        return;
+      }
 
-    this._client.prepare(this.token).then(() => this._retrieve(callback));
-  }
-
-  _retrieve(callback) {
-    return this._client[this._method]({id: this.path, token: this.token})
-      .then(this._read.bind(this, callback))
-      .catch((err) => callback(err, null));
+      this._client.prepare(this.token).then(() => {
+        this._retrieve()
+          .then((data) => resolve(data))
+          .catch((err) => reject(err));
+      });
+    });
   }
 
   /**
-   * Renew the generic secret.
-   *
-   * The method name is effectively the same as initializing the secret.
-   *
-   * The callback has the following signature: `callback(err, data)`.
-   *
-   * @param {function} callback
-   */
-  renew(callback) {
-    this._retrieve(callback);
-  }
-
-  /**
-   * Processes a `Vaulted.read/readCubby` response.
-   *
-   * @param {function} callback
-   * @param {object} response
+   * Retrieve the requested secret from Vault
+   * @returns {Promise}
    * @private
    */
-  _read(callback, response) {
-    this._value = response;
+  _retrieve() {
+    return new Promise((resolve, reject) => {
+      this._client[this._method]({id: this.path, token: this.token})
+          .then((response) => {
+            this._value = response;
 
-    callback(null, response);
+            resolve(response);
+          })
+          .catch((err) => reject(err));
+    });
+  }
+
+  /**
+   * Renew the secret.
+   *
+   * The method is effectively the same as initializing the secret.
+   *
+   * @returns {Promise}
+   */
+  renew() {
+    return this._retrieve();
   }
 }
 

--- a/lib/providers/generic.js
+++ b/lib/providers/generic.js
@@ -45,7 +45,7 @@ class GenericProvider {
    */
   initialize() {
     if (this._value) {
-      return Promise.resolve(this.renew());
+      return Promise.resolve(this._value);
     }
 
     return this._retrieve();

--- a/lib/providers/generic.js
+++ b/lib/providers/generic.js
@@ -44,16 +44,11 @@ class GenericProvider {
    * @returns {Promise}
    */
   initialize() {
-    return new Promise((resolve, reject) => {
-      if (this._value) {
-        resolve(this.renew());
-        return;
-      }
+    if (this._value) {
+      return Promise.resolve(this.renew());
+    }
 
-      this._retrieve()
-        .then((data) => resolve(data))
-        .catch((err) => reject(err));
-    });
+    return this._retrieve();
   }
 
   /**
@@ -62,17 +57,15 @@ class GenericProvider {
    * @private
    */
   _retrieve() {
-    return new Promise((resolve, reject) => {
-      this._client.prepare(this.token)
-        .then(() => {
-          this._client[this._method]({id: this.path, token: this.token})
-            .then((response) => {
-              this._value = response;
-              resolve(response);
-            })
-            .catch((err) => reject(err));
-        });
-    });
+    return this._client.prepare(this.token)
+      .then(this._client[this._method].bind(this._client, {
+        id: this.path,
+        token: this.token
+      }, null))
+      .then((response) => {
+        this._value = response;
+        return response;
+      });
   }
 
   /**

--- a/lib/providers/generic.js
+++ b/lib/providers/generic.js
@@ -46,15 +46,13 @@ class GenericProvider {
   initialize() {
     return new Promise((resolve, reject) => {
       if (this._value) {
-        reject(new Error('Already initialized'));
+        resolve(this.renew());
         return;
       }
 
-      this._client.prepare(this.token).then(() => {
-        this._retrieve()
-          .then((data) => resolve(data))
-          .catch((err) => reject(err));
-      });
+      this._retrieve()
+        .then((data) => resolve(data))
+        .catch((err) => reject(err));
     });
   }
 
@@ -65,13 +63,15 @@ class GenericProvider {
    */
   _retrieve() {
     return new Promise((resolve, reject) => {
-      this._client[this._method]({id: this.path, token: this.token})
-          .then((response) => {
-            this._value = response;
-
-            resolve(response);
-          })
-          .catch((err) => reject(err));
+      this._client.prepare(this.token)
+        .then(() => {
+          this._client[this._method]({id: this.path, token: this.token})
+            .then((response) => {
+              this._value = response;
+              resolve(response);
+            })
+            .catch((err) => reject(err));
+        });
     });
   }
 

--- a/lib/providers/token.js
+++ b/lib/providers/token.js
@@ -120,6 +120,10 @@ class TokenProvider {
    * @returns {Promise}
    */
   initialize() {
+    if (this.token) {
+      return Promise.resolve(this.renew());
+    }
+
     return new Promise((resolve, reject) => {
       this._getDocument()
         .then((data) => this._sendDocument(data))
@@ -161,7 +165,7 @@ class TokenProvider {
               token: data.auth.client_token
             });
           })
-          .catch((err) => callback(err, null));
+          .catch((err) => reject(err));
     });
   }
 

--- a/lib/providers/token.js
+++ b/lib/providers/token.js
@@ -117,48 +117,52 @@ class TokenProvider {
    * POSTs the instance identity data to Warden and then parses
    * the response to return a token.
    *
-   * @param {function} callback
+   * @returns {Promise}
    */
-  initialize(callback) {
-    this._getDocument()
-      .then((data) => this._sendDocument(data))
-      .then((data) => {
-        this.token = data.data.token;
+  initialize() {
+    return new Promise((resolve, reject) => {
+      this._getDocument()
+        .then((data) => this._sendDocument(data))
+        .then((data) => {
+          this.token = data.data.token;
 
-        callback(null, {
-          lease_id: data.data.token,
-          lease_duration: data.lease_duration,
-          data: {
-            token: this.token
-          }
-        });
-      }).catch((err) => callback(err, null));
+          resolve({
+            lease_id: data.data.token,
+            lease_duration: data.lease_duration,
+            data: {
+              token: this.token
+            }
+          });
+        }).catch((err) => reject(err));
+    });
   }
 
   /**
    * Renews the Vault auth token
-   * @param {function} callback
+   * @returns {Promise}
    */
-  renew(callback) {
-    if (!this.token) {
-      callback(new Error('This token provider has not been initialized or has not received a valid token from' +
-          ' Warden.'), null);
-      return;
-    }
+  renew() {
+    return new Promise((resolve, reject) => {
+      if (!this.token) {
+        reject(new Error('This token provider has not been initialized or has not received a valid token from' +
+            ' Warden.'));
+        return;
+      }
 
-    this._client.prepare(this.token)
-      .then(this._client.renewToken.bind(this._client, {
-        id: this.token,
-        token: this.token,
-        body: {increment: VAULT_TOKEN_TTL}
-      }, null))
-      .then((data) => {
-        callback(null, {
-          lease_duration: data.auth.lease_duration,
-          token: data.auth.client_token
-        });
-      })
-      .catch((err) => callback(err, null));
+      this._client.prepare(this.token)
+          .then(this._client.renewToken.bind(this._client, {
+            id: this.token,
+            token: this.token,
+            body: {increment: VAULT_TOKEN_TTL}
+          }, null))
+          .then((data) => {
+            resolve({
+              lease_duration: data.auth.lease_duration,
+              token: data.auth.client_token
+            });
+          })
+          .catch((err) => callback(err, null));
+    });
   }
 
   /**

--- a/lib/providers/token.js
+++ b/lib/providers/token.js
@@ -107,6 +107,7 @@ class TokenProvider {
     }
 
     this.token = null;
+    this.data = null;
 
     return this;
   }
@@ -120,21 +121,22 @@ class TokenProvider {
    * @returns {Promise}
    */
   initialize() {
-    if (this.token) {
-      return Promise.resolve(this.renew());
+    if (this.data) {
+      return Promise.resolve(this.data);
     }
     return this._getDocument()
       .then((data) => this._sendDocument(data))
       .then((data) => {
         this.token = data.data.token;
-
-        return {
+        this.data = {
           lease_id: data.data.token,
           lease_duration: data.lease_duration,
           data: {
             token: this.token
           }
         };
+
+        return this.data;
       });
   }
 
@@ -156,10 +158,14 @@ class TokenProvider {
         body: {increment: VAULT_TOKEN_TTL}
       }, null))
       .then((data) => {
-        return {
+        this.data = {
           lease_duration: data.auth.lease_duration,
-          data: data.auth.client_token
+          data: {
+            token: data.auth.client_token
+          }
         };
+
+        return this.data;
       });
   }
 

--- a/lib/providers/token.js
+++ b/lib/providers/token.js
@@ -123,22 +123,19 @@ class TokenProvider {
     if (this.token) {
       return Promise.resolve(this.renew());
     }
+    return this._getDocument()
+      .then((data) => this._sendDocument(data))
+      .then((data) => {
+        this.token = data.data.token;
 
-    return new Promise((resolve, reject) => {
-      this._getDocument()
-        .then((data) => this._sendDocument(data))
-        .then((data) => {
-          this.token = data.data.token;
-
-          resolve({
-            lease_id: data.data.token,
-            lease_duration: data.lease_duration,
-            data: {
-              token: this.token
-            }
-          });
-        }).catch((err) => reject(err));
-    });
+        return {
+          lease_id: data.data.token,
+          lease_duration: data.lease_duration,
+          data: {
+            token: this.token
+          }
+        };
+      });
   }
 
   /**
@@ -146,27 +143,24 @@ class TokenProvider {
    * @returns {Promise}
    */
   renew() {
-    return new Promise((resolve, reject) => {
-      if (!this.token) {
-        reject(new Error('This token provider has not been initialized or has not received a valid token from' +
-            ' Warden.'));
-        return;
-      }
+    if (!this.token) {
+      return Promise.reject(new Error('This token provider has not been initialized or has not received a valid' +
+          ' token from' +
+          ' Warden.'));
+    }
 
-      this._client.prepare(this.token)
-          .then(this._client.renewToken.bind(this._client, {
-            id: this.token,
-            token: this.token,
-            body: {increment: VAULT_TOKEN_TTL}
-          }, null))
-          .then((data) => {
-            resolve({
-              lease_duration: data.auth.lease_duration,
-              token: data.auth.client_token
-            });
-          })
-          .catch((err) => reject(err));
-    });
+    return this._client.prepare(this.token)
+      .then(this._client.renewToken.bind(this._client, {
+        id: this.token,
+        token: this.token,
+        body: {increment: VAULT_TOKEN_TTL}
+      }, null))
+      .then((data) => {
+        return {
+          lease_duration: data.auth.lease_duration,
+          data: data.auth.client_token
+        };
+      });
   }
 
   /**
@@ -176,16 +170,10 @@ class TokenProvider {
    * @private
    */
   _sendDocument(data) {
-    return new Promise((resolve, reject) => {
-      this._post({
-        document: JSON.parse(data[0]),
-        signature: data[1],
-        pkcs7: `-----BEGIN PKCS7-----\n${data[2]}\n-----END PKCS7-----\n`
-      }).then((data) => {
-        resolve(data);
-      }).catch((err) => {
-        reject(err);
-      })
+    return this._post({
+      document: JSON.parse(data[0]),
+      signature: data[1],
+      pkcs7: `-----BEGIN PKCS7-----\n${data[2]}\n-----END PKCS7-----\n`
     });
   }
 

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -55,20 +55,18 @@ class StorageService {
    * @returns {Promise}
    */
   lookup(token, secret, ProviderType) {
-    return new Promise((resolve, reject) => {
-      this._getLeaseManager(token, secret, ProviderType).then((manager) => {
-        if (manager.status === STATUS.READY) {
+    return this._getLeaseManager(token, secret, ProviderType).then((manager) => {
+      if (manager.status === STATUS.READY) {
 
-          // LeaseManager is ready, immediately resolve with data
-          resolve(manager.data);
-        } else {
+        // LeaseManager is ready, immediately resolve with data
+        return manager.data;
+      } else {
 
-          // Queue the promise states with a timeout
-          onceWithTimeout(manager, 'ready', this.timeout)
-              .then(() => resolve(manager.data))
-              .catch((err) => reject(err));
-        }
-      });
+        // Queue the promise states with a timeout
+        return onceWithTimeout(manager, 'ready', this.timeout).then(() => {
+          return manager.data;
+        });
+      }
     });
   }
 

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -78,14 +78,18 @@ class StorageService {
 
     let t = '';
 
+    // TODO: wait until the default token is STATUS.READY
     if (!!this.defaultToken && this.defaultToken.status === STATUS.READY) {
       t = this.defaultToken.data.token;
     }
 
-    // Otherwise, provision a new LeaseManager for the secret
+    return this._createManager(t, secret, ProviderType, secretID);
+  }
+
+  _createManager(token, secret, ProviderType, secretID) {
     // TODO: get provider configuration (options) using secret
     const options = {};
-    const provider = new ProviderType(secret, t, options);
+    const provider = new ProviderType(secret, token, options);
     const manager = new LeaseManager(provider);
 
     StorageService.setEvents(manager);

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -16,7 +16,7 @@ class StorageService {
    * Create a new instance of a StorageService.
    *
    * @param {object} [options] - configuration options
-   * @param {string} [options.timeout] - the timeout value (in millis) when looking up secrets
+   * @param {number} [options.timeout] - the timeout value (in millis) when looking up secrets
    *
    */
   constructor(options) {
@@ -24,35 +24,52 @@ class StorageService {
     this.timeout = options.timeout || DEFAULT_TIMEOUT_MILLIS;
 
     this._managers = new Map();
-    this.defaultToken = this._getLeaseManager('default', 'default', TokenProvider);
+
+  }
+
+  get defaultToken() {
+    const tokenManagerID = '/TokenProvider/default/default';
+
+    if (!!this._defaultToken) {
+      return this._managers.get(tokenManagerID);
+    } else {
+      this._defaultToken = this._createManager('default', 'default', TokenProvider, tokenManagerID);
+      return this._defaultToken;
+    }
+  }
+
+  set defaultToken(t) {
+    this._defaultToken = t;
   }
 
   /**
-   * Gets the data for the SecretProvider corresponding to the given secret, passing it to the given
-   * callback. If the underlying LeaseManager is not READY within the configured timeout period,
-   * the lookup call will timeout and the given callback will passed a timeout error.
+   * Gets the data for the SecretProvider corresponding to the given secret, and returning a
+   * Promise. If the underlying LeaseManager is not READY within the configured timeout period,
+   * the lookup call will timeout and the method will return a rejected Promise with a timeout
+   * error.
    *
    * @param {string} token - the token to use to lookup the secret (currently a no-op)
    * @param {string} secret - the secret to lookup
    * @param {TokenProvider|CubbyHoleProvider|SecretProvider|CredentialProvider} ProviderType - the type of provider
    * to instantiate
-   * @param {Function} callback - function of the form callback(err, data)
-   *
+   * @returns {Promise}
    */
-  lookup(token, secret, ProviderType, callback) {
-    const manager = this._getLeaseManager(token, secret, ProviderType);
+  lookup(token, secret, ProviderType) {
+    return new Promise((resolve, reject) => {
+      this._getLeaseManager(token, secret, ProviderType).then((manager) => {
+        if (manager.status === STATUS.READY) {
 
-    if (manager.status === STATUS.READY) {
+          // LeaseManager is ready, immediately resolve with data
+          resolve(manager.data);
+        } else {
 
-      // LeaseManager is ready, immediately callback with data
-      callback(null, manager.data);
-    } else {
-
-      // Queue the callback with a timeout
-      onceWithTimeout(manager, 'ready', this.timeout)
-        .then(() => callback(null, manager.data))
-        .catch((err) => callback(err, null));
-    }
+          // Queue the promise states with a timeout
+          onceWithTimeout(manager, 'ready', this.timeout)
+              .then(() => resolve(manager.data))
+              .catch((err) => reject(err));
+        }
+      });
+    });
   }
 
   /**
@@ -73,17 +90,15 @@ class StorageService {
 
     // If the LeaseManager is already provisioned, return it
     if (this._managers.has(secretID)) {
-      return this._managers.get(secretID);
+      return this._managers.get(secretID).initialize();
     }
 
-    let t = '';
+    return this.defaultToken.initialize().then(() => {
+      const manager = this._createManager(this.defaultToken.data.token, secret, ProviderType, secretID);
 
-    // TODO: wait until the default token is STATUS.READY
-    if (!!this.defaultToken && this.defaultToken.status === STATUS.READY) {
-      t = this.defaultToken.data.token;
-    }
-
-    return this._createManager(t, secret, ProviderType, secretID);
+      manager.initialize();
+      return manager;
+    });
   }
 
   _createManager(token, secret, ProviderType, secretID) {
@@ -93,9 +108,6 @@ class StorageService {
     const manager = new LeaseManager(provider);
 
     StorageService.setEvents(manager);
-
-    // Initialize the LeaseManager
-    manager.initialize();
 
     this._managers.set(secretID, manager);
 

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -8,10 +8,7 @@ const onceWithTimeout = require('./utils/once-with-timeout');
 const DEFAULT_TIMEOUT_MILLIS = 500;
 
 // LeaseManager status
-const STATUS = {
-  READY: 'READY',
-  PENDING: 'PENDING'
-};
+const STATUS = require('./utils/status');
 
 class StorageService {
 

--- a/lib/utils/status.js
+++ b/lib/utils/status.js
@@ -1,0 +1,5 @@
+module.exports = {
+  READY: 'READY',
+  PENDING: 'PENDING',
+  ERROR: 'ERROR'
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "node ./bin/server.js",
     "test": "mocha --require ./test/init",
     "cover": "rm -Rf coverage/* && istanbul cover _mocha -- -R spec --require ./test/init",
-    "lint": "eslint bin/* lib/*.js lib/**/*.js test/*.js test/**/*.js",
+    "lint": "eslint bin/* 'lib/**/*.js' 'test/**/*.js'",
     "report": "coveralls < ./coverage/lcov.info",
     "warden-mock": "node ./test/bin/warden.js"
   },

--- a/test/http-server-v1.js
+++ b/test/http-server-v1.js
@@ -10,20 +10,20 @@ class MockProvider {
 }
 
 class StorageServiceMock {
-  lookup(token, secret, ProviderType, callback) {
-    callback(null, null);
+  lookup(token, secret, ProviderType) {
+    return Promise.resolve(null);
   }
 }
 
 class StorageServiceMockWithTokenResponse {
-  lookup(token, secret, ProviderType, callback) {
-    callback(null, 'token');
+  lookup(token, secret, ProviderType) {
+    return Promise.resolve('token');
   }
 }
 
 class StorageServiceMockWithSecretResponse {
-  lookup(token, secret, ProviderType, callback) {
-    callback(null, {
+  lookup(token, secret, ProviderType) {
+    return Promise.resolve({
       username: 'bob',
       password: 'my-awesome-password123'
     });
@@ -31,8 +31,8 @@ class StorageServiceMockWithSecretResponse {
 }
 
 class StorageServiceMockWithError {
-  lookup(token, secret, ProviderType, callback) {
-    callback(new Error('Funky looking error message'), null);
+  lookup(token, secret, ProviderType) {
+    return Promise.reject(new Error('Funky looking error message'));
   }
 }
 

--- a/test/lease-manager.js
+++ b/test/lease-manager.js
@@ -29,9 +29,7 @@ class CountingInitializeProvider {
   }
 
   renew() {
-    return new Promise((resolve, reject) => {
-      resolve(true);
-    });
+    return Promise.resolve(true);
   }
 }
 
@@ -45,11 +43,9 @@ class CountingRenewProvider {
   }
 
   initialize() {
-    return new Promise((resolve, reject) => {
-      resolve({
-        data: 'SECRET',
-        lease_duration: 1
-      });
+    return Promise.resolve({
+      data: 'SECRET',
+      lease_duration: 1
     });
   }
 
@@ -108,25 +104,25 @@ describe('LeaseManager#constructor', function () {
   it('change status to ready when the provider eventually succeeds', function () {
     const manager = new LeaseManager(new CountingInitializeProvider(2));
 
-    return manager.initialize().then(() => {
+    return manager.initialize().catch(() => manager.initialize().then(() => {
       manager.status.should.eql('READY');
-    });
+    }));
   });
 
   it('change data to a secret when the provider eventually succeeds', function () {
     const manager = new LeaseManager(new CountingInitializeProvider(2));
 
-    return manager.initialize().then(() => {
+    return manager.initialize().catch(() => manager.initialize().then(() => {
       manager.data.should.eql('SECRET');
-    });
+    }));
   });
 
   it('change lease duration to non-zero when the provider eventually succeeds', function () {
     const manager = new LeaseManager(new CountingInitializeProvider(2));
 
-    return manager.initialize().then(() => {
+    return manager.initialize().catch(() => manager.initialize().then(() => {
       manager.lease_duration.should.eql(1);
-    });
+    }));
   });
 
   it('emits ready event when the provider succeeds', function (done) {
@@ -137,7 +133,7 @@ describe('LeaseManager#constructor', function () {
       done();
     });
 
-    manager.initialize();
+    manager.initialize().catch(() => manager.initialize());
   });
 });
 

--- a/test/provider-generic.js
+++ b/test/provider-generic.js
@@ -15,7 +15,7 @@ chai.use(require('chai-as-promised'));
 function createHttpMock() {
   const vaultHostname = `${(Config.get('vault:tls')) ? 'https' : 'http'}://${Config.get('vault:host')}:${Config.get('vault:port')}/`;
 
-  return nock(vaultHostname)
+  return nock(vaultHostname).persist()
       .get('/v1/sys/init')
       .reply(STATUS_CODES.OK, {initialized: true})
       .get('/v1/sys/seal-status')

--- a/test/provider-token.js
+++ b/test/provider-token.js
@@ -241,7 +241,7 @@ describe('Provider/Token', function() {
       this.token.token = 'somereallycooltoken';
 
       return this.token.renew().then((data) => {
-        data.should.eql({lease_duration, token: 'somereallycooltoken'});
+        data.should.eql({lease_duration, data: 'somereallycooltoken'});
       }).catch((err) => {
         should(err).be.null();
       });

--- a/test/provider-token.js
+++ b/test/provider-token.js
@@ -247,19 +247,15 @@ describe('Provider/Token', function() {
       });
     });
 
-    it('Returns a rejected Promise if the token cannot be renewed', function(done) {
+    it('Returns a rejected Promise if the token cannot be renewed', function() {
       scope.post('/v1/auth/token/renew/somereallycooltoken')
         .reply(STATUS_CODES.BAD_REQUEST, {errors: ['This token cannot be renewed']});
       this.token.token = 'somereallycooltoken';
 
-      this.token.renew((err, data) => {
-        try {
-          should(data).be.null();
-          err.should.be.an.Error();
-          done();
-        } catch (ex) {
-          done(ex);
-        }
+      this.token.renew().then((data) => {
+        should(data).be.null();
+      }).catch((err) => {
+        err.should.be.an.Error();
       });
     });
 

--- a/test/provider-token.js
+++ b/test/provider-token.js
@@ -241,7 +241,12 @@ describe('Provider/Token', function() {
       this.token.token = 'somereallycooltoken';
 
       return this.token.renew().then((data) => {
-        data.should.eql({lease_duration, data: 'somereallycooltoken'});
+        data.should.eql({
+          lease_duration,
+          data: {
+            token: 'somereallycooltoken'
+          }
+        });
       }).catch((err) => {
         should(err).be.null();
       });

--- a/test/storage-service.js
+++ b/test/storage-service.js
@@ -48,14 +48,12 @@ class MockSecretProvider {
   }
 
   initialize() {
-    return new Promise((resolve, reject) => {
-      resolve({
-        lease_id: 'token',
-        lease_duration: 60,
-        data: {
-          somesecret: 'SUPERSECRET'
-        }
-      })
+    return Promise.resolve({
+      lease_id: 'token',
+      lease_duration: 60,
+      data: {
+        somesecret: 'SUPERSECRET'
+      }
     });
   }
 }
@@ -74,14 +72,14 @@ class DelayedInitializeProvider {
   }
 
   renew() {
-    return new Promise((resolve, reject) => {
-      resolve({data: 'SECRET'});
-    });
+    return Promise.resolve({data: 'SECRET'});
   }
 }
 
 class NeverInitializeProvider {
-  initialize() {}
+  initialize() {
+    return Promise.reject(false);
+  }
 
   renew() {}
 }
@@ -110,15 +108,14 @@ describe('StorageService', function() {
 
   describe('StorageService#lookup', function () {
     it('should lookup the secret from a ready LeaseManager', function () {
-      const secret = 'test';
       const manager = new LeaseManager(new ImmediateInitializeProvider());
       const storage = setTokenProvider(new StorageService());
 
-      manager.initialize();
-      storage._managers.set(secret, manager);
-
-      return storage.lookup('default', secret, ImmediateInitializeProvider).then((data) => {
-        should(data).eql('SECRET');
+      storage._managers.set('/ImmediateInitializeProvider/default/test', manager);
+      return manager.initialize().then(() => {
+        return storage.lookup('default', 'test', ImmediateInitializeProvider).then((data) => {
+          should(data).eql('SECRET');
+        });
       });
     });
 


### PR DESCRIPTION
This PR refactors the `callback(err, data)` pattern into `Promises` in order to allow us to chain `LeaseManagers`. The scope of this PR is only to chain the default token and require it to be initialized before other secrets can be retrieved.

Later PRs will make this more generic and allow arbitrary tokens to be used and have secret requests chained behind them.

This resolves #8.