### PR TITLE
Standardize error handling

### DIFF
--- a/lib/control/util/index.js
+++ b/lib/control/util/index.js
@@ -12,8 +12,21 @@ const Handlers = {
 };
 
 const Err = (err, req, res, next) => {
-  res.status(500);
-  res.json({error: err.message});
+  const error = {
+    error: {
+      name: err.name,
+      message: err.message
+    }
+  };
+  const statusCode = err.statusCode || STATUS_CODES.BAD_REQUEST;
+
+  // Include response headers if it's a HTTP error
+  if (err.response) {
+    error.error.headers = err.response.headers;
+  }
+
+  res.status(statusCode);
+  res.json(error);
 };
 
 module.exports = {

--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -37,7 +37,7 @@ class LeaseManager extends EventEmitter {
       this.emit('ready');
       this.error = null;
       this._renew();
-      return Promise.resolve(this);
+      return this;
     }).catch((err) => {
       this.status = STATUS.PENDING;
       this.data = null;
@@ -46,11 +46,7 @@ class LeaseManager extends EventEmitter {
         this.emit('error', err);
       }
       this.error = err;
-
-      // TODO: This isn't great. We need a combination of exponential backoff and having re-initialization on
-      // correction of the error condition occur elsewhere.
-      // return this.initialize();
-      return Promise.reject(err);
+      throw err;
     });
   }
 

--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -11,14 +11,16 @@ class LeaseManager extends EventEmitter {
   /**
    * Create a new instance of a LeaseManager with the given SecretProvider
    * @param {TokenProvider|GenericProvider} provider
+   * @param {string} name
    */
-  constructor(provider) {
+  constructor(provider, name) {
     super();
 
     this.status = STATUS.PENDING;
     this.data = null;
     this.lease_duration = 0;
     this.provider = provider;
+    this.name = name;
     this.error = null;
   }
 

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -103,7 +103,7 @@ class StorageService {
     // TODO: get provider configuration (options) using secret
     const options = {};
     const provider = new ProviderType(secret, token, options);
-    const manager = new LeaseManager(provider);
+    const manager = new LeaseManager(provider, secretID);
 
     StorageService.setEvents(manager);
 

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -65,6 +65,9 @@ class StorageService {
         // Queue the promise states with a timeout
         return onceWithTimeout(manager, 'ready', this.timeout).then(() => {
           return manager.data;
+        }).catch((err) => {
+          this._managers.delete(manager.name);
+          throw err;
         });
       }
     });

--- a/test/http-server-v1.js
+++ b/test/http-server-v1.js
@@ -109,7 +109,10 @@ describe('v1 API', function () {
 
       util.testEndpointResponse(endpoint, (err, res) => {
         res.body.should.eql({
-          error: 'Funky looking error message'
+          error: {
+            message: 'Funky looking error message',
+            name: 'Error'
+          }
         });
         done();
       });
@@ -148,7 +151,10 @@ describe('v1 API', function () {
 
       util.testEndpointResponse(endpoint, (err, res) => {
         res.body.should.eql({
-          error: 'Funky looking error message'
+          error: {
+            message: 'Funky looking error message',
+            name: 'Error'
+          }
         });
         done();
       });

--- a/test/storage-service.js
+++ b/test/storage-service.js
@@ -84,6 +84,12 @@ class NeverInitializeProvider {
   renew() {}
 }
 
+class ErrorThrowingProvider {
+  initialize() {
+    return Promise.reject(new Error('This is a funny looking error'));
+  }
+}
+
 function setTokenProvider(storage) {
   const l = new LeaseManager(new MockTokenProvider());
 
@@ -202,6 +208,15 @@ describe('StorageService', function() {
         const lm = storage._managers.get('/MockSecretProvider/default/somesecret');
 
         lm.provider.token.should.not.eql('');
+      });
+    });
+
+    it('should remove a Provider from StorageService#_mangers if it raises an error', function () {
+      const storage = setTokenProvider(new StorageService());
+
+      return storage.lookup('default', 'somesecret', NeverInitializeProvider).catch(() => {
+        storage._managers.size.should.equal(1);
+        storage._managers.has('/NeverInitializeProvider/default/somesecret').should.be.false();
       });
     });
   });

--- a/test/storage-service.js
+++ b/test/storage-service.js
@@ -84,12 +84,6 @@ class NeverInitializeProvider {
   renew() {}
 }
 
-class ErrorThrowingProvider {
-  initialize() {
-    return Promise.reject(new Error('This is a funny looking error'));
-  }
-}
-
 function setTokenProvider(storage) {
   const l = new LeaseManager(new MockTokenProvider());
 


### PR DESCRIPTION
This PR standardizes the way we handle errors that bubble up from `Providers`. I'm soliciting feedback on what we want our error output to look like. This PR defines it as the following:

```javascript
{
    error: {
      name: err.name,
      message: err.message,
      headers: err.response.headers // If the error is HTTP-based
    }
  }
```
with a `400` status code unless the error is HTTP-based and has its own `statusCode`.