### PR TITLE
Bug: Multiple token requests

### DIFF
--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -22,6 +22,12 @@ class LeaseManager extends EventEmitter {
     this.provider = provider;
     this.name = name;
     this.error = null;
+
+    this.on('renewed', () => {
+      // We've renewed at least once. Can't call _renew again or else
+      // we'll create multiple timers
+      this.status = STATUS.READY;
+    });
   }
 
   /**
@@ -33,15 +39,19 @@ class LeaseManager extends EventEmitter {
    */
   initialize() {
     return this.provider.initialize().then((result) => {
-      this.status = STATUS.READY;
       this.data = result.data;
       this.lease_duration = result.lease_duration;
-      this.emit('ready');
-      this.error = null;
-      this._renew();
+
+      if (this.status !== STATUS.READY) {
+        this.status = STATUS.READY;
+        this.emit('ready');
+        this.error = null;
+        this._renew();
+      }
+
       return this;
     }).catch((err) => {
-      this.status = STATUS.PENDING;
+      this.status = STATUS.ERROR;
       this.data = null;
       this.lease_duration = 0;
       if (this.listeners('error').length > 0) {

--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -52,9 +52,7 @@ class LeaseManager extends EventEmitter {
 
   /**
    * Initialize the SecretProvider
-   *
-   * TODO: Make this method way less problematic
-   *
+   * 
    * @returns {Promise}
    */
   initialize() {

--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -23,10 +23,27 @@ class LeaseManager extends EventEmitter {
     this.name = name;
     this.error = null;
 
-    this.on('renewed', () => {
-      // We've renewed at least once. Can't call _renew again or else
-      // we'll create multiple timers
+    this.on('renewed', (result) => {
+      this.lease_duration = result.lease_duration;
+      this.data = result.data;
       this.status = STATUS.READY;
+    });
+
+    this.on('ready', () => {
+      this.status = STATUS.READY;
+      this.error = null;
+    });
+
+    this.on('error', (err) => {
+      this.status = STATUS.ERROR;
+
+      // Clear timer so we can renew again
+      clearInterval(this._timer);
+      this._timer = null;
+
+      this.data = null;
+      this.lease_duration = 0;
+      this.error = err;
     });
   }
 
@@ -42,46 +59,45 @@ class LeaseManager extends EventEmitter {
       this.data = result.data;
       this.lease_duration = result.lease_duration;
 
+      this._renew();
       if (this.status !== STATUS.READY) {
-        this.status = STATUS.READY;
         this.emit('ready');
-        this.error = null;
-        this._renew();
       }
 
       return this;
     }).catch((err) => {
-      this.status = STATUS.ERROR;
-      this.data = null;
-      this.lease_duration = 0;
-      if (this.listeners('error').length > 0) {
-        this.emit('error', err);
-      }
-      this.error = err;
+      this.emit('error', err);
+
       throw err;
     });
   }
 
   /**
    * Renew the lease from the SecretProvider
+   * @return {LeaseManager}
    * @private
    */
   _renew() {
     const timeout = (this.lease_duration / 2) * 1000; // eslint-disable-line rapid7/static-magic-numbers
 
-    setTimeout(() => {
+    if (this._timer && this._timeout === timeout) {
+      return this;
+    } else {
+      clearInterval(this._timer);
+      this._timeout = timeout;
+    }
+
+    this._timer = setInterval(() => {
       this.provider.renew().then((result) => {
-        this.lease_duration = result.lease_duration;
-        this.data = result.data;
-        this.emit('renewed');
+        this.emit('renewed', result);
         this._renew();
       }).catch((err) => {
-        this.error = err;
-        this.status = STATUS.PENDING;
-        this.lease_duration = 0;
+        this.emit('error', err);
         this.initialize();
       });
-    }, timeout);
+    }, this._timeout);
+
+    return this;
   }
 }
 

--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -35,14 +35,17 @@ class LeaseManager extends EventEmitter {
     });
 
     this.on('error', (err) => {
+      if (this.status !== STATUS.READY) {
+        this.data = null;
+        this.lease_duration = 0;
+      }
+
       this.status = STATUS.ERROR;
 
       // Clear timer so we can renew again
       clearInterval(this._timer);
       this._timer = null;
 
-      this.data = null;
-      this.lease_duration = 0;
       this.error = err;
     });
   }

--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -62,12 +62,11 @@ class LeaseManager extends EventEmitter {
       this.data = result.data;
       this.lease_duration = result.lease_duration;
 
-      this._renew();
       if (this.status !== STATUS.READY) {
         this.emit('ready');
       }
 
-      return this;
+      return this._renew();
     }).catch((err) => {
       this.emit('error', err);
 

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -83,18 +83,18 @@ class StorageService {
    * @param {TokenProvider|CubbyHoleProvider|SecretProvider|CredentialProvider} ProviderType - the type of provider
    * to instantiate
    *
-   * @returns {LeaseManager}
+   * @returns {Promise<LeaseManager>}
    *
    */
   _getLeaseManager(token, secret, ProviderType) {
     const secretID = `/${ProviderType.prototype.constructor.name}/${token}/${secret}`;
 
-    // If the LeaseManager is already provisioned, return it
-    if (this._managers.has(secretID)) {
-      return this._managers.get(secretID).initialize();
-    }
-
     return this.defaultToken.initialize().then(() => {
+      // If the LeaseManager is already provisioned, return it
+      if (this._managers.has(secretID)) {
+        return this._managers.get(secretID).initialize();
+      }
+
       const manager = this._createManager(this.defaultToken.data.token, secret, ProviderType, secretID);
 
       manager.initialize();

--- a/test/bin/metadata-server.js
+++ b/test/bin/metadata-server.js
@@ -30,6 +30,9 @@ function deepGet(root, path) {
 
   path.split('/').forEach((branch, index, branches) => {
     if (branch) {
+      if (!twig.hasOwnProperty(branch)) {
+        return null;
+      }
       if (index < branches.length - 1) {
         twig = twig[branch];
       } else {

--- a/test/lease-manager.js
+++ b/test/lease-manager.js
@@ -4,6 +4,7 @@ const should = require('should');
 
 const LeaseManager = require('../lib/lease-manager');
 
+/* eslint-disable no-inline-comments */
 /**
  * A mock SecretProvider that fails to initialize N times before succeeding
  */

--- a/test/lease-manager.js
+++ b/test/lease-manager.js
@@ -241,7 +241,7 @@ describe('LeaseManager#_renew', function () {
         renewal = true;
       } else {
         manager._timer.should.not.equal(timer);
-        manager._timer._idleTimeout.should.equal(1000) // 2 seconds / 2
+        manager._timer._idleTimeout.should.equal(1000); // 2 seconds / 2
         done();
       }
     });

--- a/test/lease-manager.js
+++ b/test/lease-manager.js
@@ -251,7 +251,7 @@ describe('LeaseManager#_renew', function () {
     })
   });
 
-  it.only('shouldn\'t clear the provider data when renewal fails', function (done) {
+  it('shouldn\'t clear the provider data when renewal fails', function (done) {
     const manager = new LeaseManager(new FailToRenewProvider());
 
     manager.on('error', () => {

--- a/test/lease-manager.js
+++ b/test/lease-manager.js
@@ -188,7 +188,7 @@ describe('LeaseManager#_renew', function () {
     manager.initialize();
   });
 
-  it('shouldn\t try to change #_timer unless the token/secret timeout has changed', function (done) {
+  it('should change the #_timer if the token/secret timeout has changed', function (done) {
     const manager = new LeaseManager(new ChangingTimeoutProvider());
     let timer = null,
         renewal = false;

--- a/test/lease-manager.js
+++ b/test/lease-manager.js
@@ -254,7 +254,7 @@ describe('LeaseManager#_renew', function () {
   it('shouldn\'t clear the provider data when renewal fails', function (done) {
     const manager = new LeaseManager(new FailToRenewProvider());
 
-    manager.on('error', () => {
+    manager.once('error', () => {
       manager.data.should.not.be.null();
       manager.lease_duration.should.not.equal(0);
       done();

--- a/test/lease-manager.js
+++ b/test/lease-manager.js
@@ -229,13 +229,8 @@ describe('LeaseManager#_renew', function () {
     let timer = null,
         renewal = false;
 
-    manager.on('ready', () => {
-      timer = manager._timer;
-    });
-
     manager.on('renewed', () => {
       if (!renewal) {
-        manager._timer.should.equal(timer);
         timer = manager._timer;
         timer._idleTimeout.should.equal(500); // 1 second / 2
         renewal = true;


### PR DESCRIPTION
This PR fixes #54. A race condition previously existed where two `defaultToken`s would be retrieved at the same time. This requires all token provisioning to require the `defaultToken` to be initialized before `initialize()` is called on their `LeaseManager`.

In addition, it refactors some of the `LeaseManager` to be a bit more stateful.