### PR TITLE
Feature: Transit secret provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ node_modules
 .node_repl_history
 .bundle/
 .builderator/
+.idea/
 
 cookbook/metadata.json

--- a/lib/providers/transit.js
+++ b/lib/providers/transit.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const Vaulted = require('vaulted');
+const preconditions = require('conditional');
+const checkNotEmpty = preconditions.checkNotEmpty;
+
+// Default Vault connection options
+const VAULT_CONFIG = {
+  vault_host: Config.get('vault:host'),
+  vault_port: Config.get('vault:port'),
+  vault_ssl: Config.get('vault:tls')
+};
+
+/**
+ * The TransitProvider is responsible for retrieving secrets from Vault's transit secret backend.
+ * https://www.vaultproject.io/docs/secrets/transit/index.html
+ */
+class TransitProvider {
+  /**
+   * Create a new instance of a TransitProvider.
+   *
+   * @param {String} key -
+   */
+  constructor(key) {
+    checkNotEmpty(key, 'key is required');
+  }
+}
+
+module.exports = TransitProvider;

--- a/lib/providers/transit.js
+++ b/lib/providers/transit.js
@@ -19,20 +19,22 @@ class TransitProvider {
   /**
    * Create a new instance of a TransitProvider.
    *
-   * @param {String} key - Key in Vault to use for decryption
+   * @param {Object} secret
+   * @param {Object} secret.key - Key in Vault to use for decryption
+   * @param {Object} secret.ciphertext - Ciphertext to decrypt
    * @param {String} token - Token to pass to Vault's API
-   * @param {Object} parameters - Arguments to pass to Vault's /transit/decrypt/ API
-   * @param {Object} parameters.ciphertext - Ciphertext to decrypt
    */
-  constructor(key, token, parameters) {
-    checkNotEmpty(key, 'key is required');
+  constructor(secret, token) {
+    checkNotEmpty(secret, 'secret is required');
+    checkNotEmpty(secret.key, 'secret.key is required');
+    checkNotEmpty(secret.ciphertext, 'secret.ciphertext is required');
     checkNotEmpty(token, 'token is required');
-    checkNotEmpty(parameters, 'parameters is required');
-    checkNotEmpty(parameters.ciphertext, 'parameters.ciphertext is required');
 
-    this._key = key;
+    this._key = secret.key;
     this._token = token;
-    this._parameters = parameters;
+    this._parameters = {
+      ciphertext: secret.ciphertext
+    };
 
     this._client = new Vaulted(VAULT_CONFIG);
     this._client.api.mountEndpoints(this._client.config, 'transit', 'transit');

--- a/lib/providers/transit.js
+++ b/lib/providers/transit.js
@@ -19,15 +19,54 @@ class TransitProvider {
   /**
    * Create a new instance of a TransitProvider.
    *
-   * @param {String} key -
-   * @param {String} token -
-   * @param {Object} parameters -
+   * @param {String} key - Key in Vault to use for decryption
+   * @param {String} token - Token to pass to Vault's API
+   * @param {Object} parameters - Arguments to pass to Vault's /transit/decrypt/ API
+   * @param {Object} parameters.ciphertext - Ciphertext to decrypt
    */
   constructor(key, token, parameters) {
     checkNotEmpty(key, 'key is required');
     checkNotEmpty(token, 'token is required');
     checkNotEmpty(parameters, 'parameters is required');
     checkNotEmpty(parameters.ciphertext, 'parameters.ciphertext is required');
+
+    this._key = key;
+    this._token = token;
+    this._parameters = parameters;
+
+    this._client = new Vaulted(VAULT_CONFIG);
+    this._plaintext = null;
+  }
+
+  /**
+   * Decrypt the ciphertext
+   *
+   * @return {Promise} - Resolves with decrypted ciphertext; rejects with an Error if decryption fails
+   */
+  initialize() {
+    if (this._plaintext) {
+      return Promise.resolve(this._plaintext);
+    }
+    return this._decrypt();
+  }
+
+  /**
+   * Decrypt the ciphertext using Vault's /transit/decrypt/ API
+   *
+   * @return {Promise} - Resolves with decrypted ciphertext; rejects with an Error if decryption fails
+   * @private
+   */
+  _decrypt() {
+    return this._client.prepare(this._token)
+      .then(this._client.decryptTransitCipherText.bind(this._client, {
+        id: this._key,
+        token: this._token,
+        body: this._parameters
+      }, null))
+      .then((response) => {
+        this._plaintext = response;
+        return response;
+      });
   }
 }
 

--- a/lib/providers/transit.js
+++ b/lib/providers/transit.js
@@ -52,6 +52,15 @@ class TransitProvider {
   }
 
   /**
+   * Decrypt the ciphertext
+   *
+   * @return {Promise} - Resolves with decrypted ciphertext; rejects with an Error if decryption fails
+   */
+  renew() {
+    return this._decrypt();
+  }
+
+  /**
    * Decrypt the ciphertext using Vault's /transit/decrypt/ API
    *
    * @return {Promise} - Resolves with decrypted ciphertext; rejects with an Error if decryption fails

--- a/lib/providers/transit.js
+++ b/lib/providers/transit.js
@@ -21,10 +21,13 @@ class TransitProvider {
    *
    * @param {String} key -
    * @param {String} token -
+   * @param {Object} parameters -
    */
-  constructor(key, token) {
+  constructor(key, token, parameters) {
     checkNotEmpty(key, 'key is required');
     checkNotEmpty(token, 'token is required');
+    checkNotEmpty(parameters, 'parameters is required');
+    checkNotEmpty(parameters.ciphertext, 'parameters.ciphertext is required');
   }
 }
 

--- a/lib/providers/transit.js
+++ b/lib/providers/transit.js
@@ -35,6 +35,7 @@ class TransitProvider {
     this._parameters = parameters;
 
     this._client = new Vaulted(VAULT_CONFIG);
+    this._client.api.mountEndpoints(this._client.config, 'transit', 'transit');
     this._plaintext = null;
   }
 

--- a/lib/providers/transit.js
+++ b/lib/providers/transit.js
@@ -37,7 +37,6 @@ class TransitProvider {
     };
 
     this._client = new Vaulted(VAULT_CONFIG);
-    this._client.api.mountEndpoints(this._client.config, 'transit', 'transit');
     this._plaintext = null;
   }
 

--- a/lib/providers/transit.js
+++ b/lib/providers/transit.js
@@ -20,9 +20,11 @@ class TransitProvider {
    * Create a new instance of a TransitProvider.
    *
    * @param {String} key -
+   * @param {String} token -
    */
-  constructor(key) {
+  constructor(key, token) {
     checkNotEmpty(key, 'key is required');
+    checkNotEmpty(token, 'token is required');
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lodash": "^4.13.0",
     "morgan": "^1.7.0",
     "nconf": "^0.8.4",
-    "vaulted": "chiefy/vaulted#5b4c6f7",
+    "vaulted": "^3.2.0",
     "winston": "^2.2.0",
     "yargs": "^4.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lodash": "^4.13.0",
     "morgan": "^1.7.0",
     "nconf": "^0.8.4",
-    "vaulted": "chiefy/vaulted#d451368",
+    "vaulted": "chiefy/vaulted#785378a",
     "winston": "^2.2.0",
     "yargs": "^4.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lodash": "^4.13.0",
     "morgan": "^1.7.0",
     "nconf": "^0.8.4",
-    "vaulted": "^3.0.1",
+    "vaulted": "chiefy/vaulted#d451368",
     "winston": "^2.2.0",
     "yargs": "^4.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lodash": "^4.13.0",
     "morgan": "^1.7.0",
     "nconf": "^0.8.4",
-    "vaulted": "chiefy/vaulted#785378a",
+    "vaulted": "chiefy/vaulted#5b4c6f7",
     "winston": "^2.2.0",
     "yargs": "^4.7.0"
   },

--- a/test/provider-transit.js
+++ b/test/provider-transit.js
@@ -38,6 +38,7 @@ describe('Provider/Transit', function () {
       localVaultMock = null;
 
   before(function () {
+    nock.cleanAll();
     globalVaultMock = createVaultMock({global: true});
   });
 
@@ -51,6 +52,7 @@ describe('Provider/Transit', function () {
 
   after(function () {
     nock.removeInterceptor(globalVaultMock);
+    nock.cleanAll();
   });
 
   describe('TransitProvider#constructor', function () {

--- a/test/provider-transit.js
+++ b/test/provider-transit.js
@@ -13,5 +13,11 @@ describe('Provider/Transit', function () {
         return new TransitProvider('', 'TOKEN', {ciphertext: 'CTEXT'});
       }, preconditions.IllegalValueError);
     });
+
+    it('throws an IllegalValueError if the token is not provided', function () {
+      should.throws(() => {
+        return new TransitProvider('KEY', '', {ciphertext: 'CTEXT'});
+      }, preconditions.IllegalValueError);
+    });
   });
 });

--- a/test/provider-transit.js
+++ b/test/provider-transit.js
@@ -19,5 +19,17 @@ describe('Provider/Transit', function () {
         return new TransitProvider('KEY', '', {ciphertext: 'CTEXT'});
       }, preconditions.IllegalValueError);
     });
+
+    it('throws an IllegalValueError if the parameters are not provided', function () {
+      should.throws(() => {
+        return new TransitProvider('KEY', '', null);
+      }, preconditions.IllegalValueError);
+    });
+
+    it('throws an IllegalValueError if parameters.ciphertext is not provided', function () {
+      should.throws(() => {
+        return new TransitProvider('KEY', '', {plaintext: 'PTEXT'});
+      }, preconditions.IllegalValueError);
+    });
   });
 });

--- a/test/provider-transit.js
+++ b/test/provider-transit.js
@@ -117,6 +117,26 @@ describe('Provider/Transit', function () {
       })
       .catch(done);
     });
+
+    it('fails with an error if the key does not exist', function (done) {
+      const transit = new TransitProvider('INVALID-KEY', 'TOKEN', {ciphertext: 'CTEXT'});
+
+      localVaultMock.post('/v1/transit/decrypt/INVALID-KEY', {
+        ciphertext: 'CTEXT'
+      })
+      .reply(STATUS_CODES.BAD_REQUEST, {
+        errors: ['policy not found']
+      });
+
+      transit.initialize()
+      .then(() => done(new Error('Invalid keys should fail!')))
+      .catch((err) => {
+        should(err).be.instanceOf(Error);
+
+        localVaultMock.done();
+        done();
+      });
+    });
   });
 
   describe('TransitProvider#renew', function () {

--- a/test/provider-transit.js
+++ b/test/provider-transit.js
@@ -1,0 +1,17 @@
+'use strict';
+
+require('./init');
+
+const TransitProvider = require('../lib/providers/transit');
+const preconditions = require('conditional');
+const should = require('should');
+
+describe('Provider/Transit', function () {
+  describe('TransitProvider#constructor', function () {
+    it('throws an IllegalValueError if the key is not provided', function () {
+      should.throws(() => {
+        return new TransitProvider('', 'TOKEN', {ciphertext: 'CTEXT'});
+      }, preconditions.IllegalValueError);
+    });
+  });
+});

--- a/test/provider-transit.js
+++ b/test/provider-transit.js
@@ -118,4 +118,40 @@ describe('Provider/Transit', function () {
       .catch(done);
     });
   });
+
+  describe('TransitProvider#renew', function () {
+    it('calls Vault every time when renewing', function (done) {
+      const transit = new TransitProvider('KEY', 'TOKEN', {ciphertext: 'CTEXT'});
+
+      localVaultMock.post('/v1/transit/decrypt/KEY', {
+        ciphertext: 'CTEXT'
+      })
+      .reply(STATUS_CODES.OK, {
+        plaintext: 'PTEXT'
+      })
+      .post('/v1/transit/decrypt/KEY', {
+        ciphertext: 'CTEXT'
+      })
+      .reply(STATUS_CODES.OK, {
+        plaintext: 'PTEXT'
+      });
+
+      transit.renew()
+      .then((retrievedPlaintext) => {
+        should(retrievedPlaintext).eql({
+          plaintext: 'PTEXT'
+        });
+      })
+      .then(() => transit.renew())
+      .then((renewedPlaintext) => {
+        should(renewedPlaintext).eql({
+          plaintext: 'PTEXT'
+        });
+
+        localVaultMock.done();
+        done();
+      })
+      .catch(done);
+    });
+  });
 });

--- a/test/provider-transit.js
+++ b/test/provider-transit.js
@@ -3,7 +3,9 @@
 require('./init');
 
 const TransitProvider = require('../lib/providers/transit');
+const STATUS_CODES = require('../lib/control/util/status-codes');
 const preconditions = require('conditional');
+const nock = require('nock');
 const should = require('should');
 
 describe('Provider/Transit', function () {
@@ -38,6 +40,77 @@ describe('Provider/Transit', function () {
           return new TransitProvider('KEY', 'TOKEN', {ciphertext: value});
         }, preconditions.IllegalValueError, `invalid "parameters.ciphertext" argument: ${value}`);
       });
+    });
+  });
+
+  function createVaultMock(options) {
+    const vaultHostname = `${(Config.get('vault:tls')) ? 'https' : 'http'}://${Config.get('vault:host')}:${Config.get('vault:port')}/`;
+
+    if (!options.global) {
+      return nock(vaultHostname);
+    }
+
+    return nock(vaultHostname).persist()
+      .get('/v1/sys/init')
+      .reply(STATUS_CODES.OK, {initialized: true})
+      .get('/v1/sys/seal-status')
+      .reply(STATUS_CODES.OK, {sealed: false, t: 1, n: 1, progress: 1})
+      .get('/v1/sys/mounts')
+      .reply(STATUS_CODES.OK, {'transit/': {config: {default_lease_ttl: 0, max_lease_ttl: 0}, type: 'transit'}})
+      .get('/v1/sys/auth')
+      .reply(STATUS_CODES.OK, {'token/': {type: 'token'}})
+      .post('/v1/sys/mounts/transit', {type: 'transit', description: 'Transit Secrets Backend transit'})
+      .reply(STATUS_CODES.OK, {'token/': {type: 'token'}});
+  }
+
+  describe('TransitProvider#initialize', function () {
+    let globalVaultMock = null,
+        localVaultMock = null;
+
+    before(function () {
+      globalVaultMock = createVaultMock({global: true});
+    });
+
+    beforeEach(function () {
+      localVaultMock = createVaultMock({global: false});
+    });
+
+    afterEach(function () {
+      nock.removeInterceptor(localVaultMock);
+    });
+
+    after(function () {
+      nock.removeInterceptor(globalVaultMock);
+    });
+
+    it('calls Vault once when initializing', function (done) {
+      const transit = new TransitProvider('KEY', 'TOKEN', {ciphertext: 'CTEXT'});
+
+      localVaultMock.post('/v1/transit/decrypt/KEY', {
+        ciphertext: 'CTEXT'
+      })
+      .reply(STATUS_CODES.OK, {
+        plaintext: 'PTEXT'
+      });
+
+      transit._client.prepare(transit._token)
+      .then(() => transit._client.mountTransit({token: transit._token}))
+      .then(() => transit.initialize())
+      .then((retrievedPlaintext) => {
+        should(retrievedPlaintext).eql({
+          plaintext: 'PTEXT'
+        });
+      })
+      .then(() => transit.initialize())
+      .then((cachedPlaintext) => {
+        should(cachedPlaintext).eql({
+          plaintext: 'PTEXT'
+        });
+
+        localVaultMock.done();
+        done();
+      })
+      .catch(done);
     });
   });
 });

--- a/test/provider-transit.js
+++ b/test/provider-transit.js
@@ -153,5 +153,25 @@ describe('Provider/Transit', function () {
       })
       .catch(done);
     });
+
+    it('fails with an error if the key does not exist', function (done) {
+      const transit = new TransitProvider('INVALID-KEY', 'TOKEN', {ciphertext: 'CTEXT'});
+
+      localVaultMock.post('/v1/transit/decrypt/INVALID-KEY', {
+        ciphertext: 'CTEXT'
+      })
+      .reply(STATUS_CODES.BAD_REQUEST, {
+        errors: ['policy not found']
+      });
+
+      transit.renew()
+      .then(() => done(new Error('Invalid keys should fail!')))
+      .catch((err) => {
+        should(err).be.instanceOf(Error);
+
+        localVaultMock.done();
+        done();
+      });
+    });
   });
 });

--- a/test/provider-transit.js
+++ b/test/provider-transit.js
@@ -8,7 +8,53 @@ const preconditions = require('conditional');
 const nock = require('nock');
 const should = require('should');
 
+/**
+ * Create a mock Vault server
+ *
+ * @param {Object} options - Options to use when setting up a mock Vault server
+ * @param {Boolean} options.global - True if the mocked Vault server should define setup API calls
+ * @return {Nock} - The mock Vault server
+ */
+function createVaultMock(options) {
+  const vaultHostname = `${(Config.get('vault:tls')) ? 'https' : 'http'}://${Config.get('vault:host')}:${Config.get('vault:port')}/`;
+
+  if (!options.global) {
+    return nock(vaultHostname);
+  }
+
+  return nock(vaultHostname).persist()
+    .get('/v1/sys/init')
+    .reply(STATUS_CODES.OK, {initialized: true})
+    .get('/v1/sys/seal-status')
+    .reply(STATUS_CODES.OK, {sealed: false, t: 1, n: 1, progress: 1})
+    .get('/v1/sys/mounts')
+    .reply(STATUS_CODES.OK, {'transit/': {config: {default_lease_ttl: 0, max_lease_ttl: 0}, type: 'transit'}})
+    .get('/v1/sys/auth')
+    .reply(STATUS_CODES.OK, {'token/': {type: 'token'}})
+    .post('/v1/sys/mounts/transit', {type: 'transit', description: 'Transit Secrets Backend transit'})
+    .reply(STATUS_CODES.OK, {'token/': {type: 'token'}});
+}
+
 describe('Provider/Transit', function () {
+  let globalVaultMock = null,
+      localVaultMock = null;
+
+  before(function () {
+    globalVaultMock = createVaultMock({global: true});
+  });
+
+  beforeEach(function () {
+    localVaultMock = createVaultMock({global: false});
+  });
+
+  afterEach(function () {
+    nock.removeInterceptor(localVaultMock);
+  });
+
+  after(function () {
+    nock.removeInterceptor(globalVaultMock);
+  });
+
   describe('TransitProvider#constructor', function () {
     it('requires key be provided', function () {
       [null, undefined, ''].forEach(function (value) {
@@ -43,46 +89,7 @@ describe('Provider/Transit', function () {
     });
   });
 
-  function createVaultMock(options) {
-    const vaultHostname = `${(Config.get('vault:tls')) ? 'https' : 'http'}://${Config.get('vault:host')}:${Config.get('vault:port')}/`;
-
-    if (!options.global) {
-      return nock(vaultHostname);
-    }
-
-    return nock(vaultHostname).persist()
-      .get('/v1/sys/init')
-      .reply(STATUS_CODES.OK, {initialized: true})
-      .get('/v1/sys/seal-status')
-      .reply(STATUS_CODES.OK, {sealed: false, t: 1, n: 1, progress: 1})
-      .get('/v1/sys/mounts')
-      .reply(STATUS_CODES.OK, {'transit/': {config: {default_lease_ttl: 0, max_lease_ttl: 0}, type: 'transit'}})
-      .get('/v1/sys/auth')
-      .reply(STATUS_CODES.OK, {'token/': {type: 'token'}})
-      .post('/v1/sys/mounts/transit', {type: 'transit', description: 'Transit Secrets Backend transit'})
-      .reply(STATUS_CODES.OK, {'token/': {type: 'token'}});
-  }
-
   describe('TransitProvider#initialize', function () {
-    let globalVaultMock = null,
-        localVaultMock = null;
-
-    before(function () {
-      globalVaultMock = createVaultMock({global: true});
-    });
-
-    beforeEach(function () {
-      localVaultMock = createVaultMock({global: false});
-    });
-
-    afterEach(function () {
-      nock.removeInterceptor(localVaultMock);
-    });
-
-    after(function () {
-      nock.removeInterceptor(globalVaultMock);
-    });
-
     it('calls Vault once when initializing', function (done) {
       const transit = new TransitProvider('KEY', 'TOKEN', {ciphertext: 'CTEXT'});
 

--- a/test/provider-transit.js
+++ b/test/provider-transit.js
@@ -56,42 +56,42 @@ describe('Provider/Transit', function () {
   });
 
   describe('TransitProvider#constructor', function () {
-    it('requires key be provided', function () {
+    it('requires secret be provided', function () {
       [null, undefined, ''].forEach(function (value) {
         should.throws(() => {
-          return new TransitProvider(value, 'TOKEN', {ciphertext: 'CTEXT'});
-        }, preconditions.IllegalValueError, `invalid "key" argument: ${value}`);
+          return new TransitProvider(value, 'TOKEN');
+        }, preconditions.IllegalValueError, `invalid "secret" argument: ${value}`);
       });
     });
 
     it('requires token be provided', function () {
       [null, undefined, ''].forEach(function (value) {
         should.throws(() => {
-          return new TransitProvider('KEY', value, {ciphertext: 'CTEXT'});
+          return new TransitProvider({key: 'KEY', ciphertext: 'CTEXT'}, value);
         }, preconditions.IllegalValueError, `invalid "token" argument: ${value}`);
       });
     });
 
-    it('requires parameters be provided', function () {
+    it('requires secret.key be provided', function () {
       [null, undefined, ''].forEach(function (value) {
         should.throws(() => {
-          return new TransitProvider('KEY', 'TOKEN', value);
-        }, preconditions.IllegalValueError, `invalid "parameters" argument: ${value}`);
+          return new TransitProvider({key: value, ciphertext: 'CTEXT'}, 'TOKEN');
+        }, preconditions.IllegalValueError, `invalid "secret.key" argument: ${value}`);
       });
     });
 
-    it('requires parameters.ciphertext be provided', function () {
+    it('requires secret.ciphertext be provided', function () {
       [null, undefined, ''].forEach(function (value) {
         should.throws(() => {
-          return new TransitProvider('KEY', 'TOKEN', {ciphertext: value});
-        }, preconditions.IllegalValueError, `invalid "parameters.ciphertext" argument: ${value}`);
+          return new TransitProvider({key: 'KEY', ciphertext: value}, 'TOKEN');
+        }, preconditions.IllegalValueError, `invalid "secret.ciphertext" argument: ${value}`);
       });
     });
   });
 
   describe('TransitProvider#initialize', function () {
     it('calls Vault once when initializing', function (done) {
-      const transit = new TransitProvider('KEY', 'TOKEN', {ciphertext: 'CTEXT'});
+      const transit = new TransitProvider({key: 'KEY', ciphertext: 'CTEXT'}, 'TOKEN');
 
       localVaultMock.post('/v1/transit/decrypt/KEY', {
         ciphertext: 'CTEXT'
@@ -119,7 +119,7 @@ describe('Provider/Transit', function () {
     });
 
     it('fails with an error if the key does not exist', function (done) {
-      const transit = new TransitProvider('INVALID-KEY', 'TOKEN', {ciphertext: 'CTEXT'});
+      const transit = new TransitProvider({key: 'INVALID-KEY', ciphertext: 'CTEXT'}, 'TOKEN');
 
       localVaultMock.post('/v1/transit/decrypt/INVALID-KEY', {
         ciphertext: 'CTEXT'
@@ -141,7 +141,7 @@ describe('Provider/Transit', function () {
 
   describe('TransitProvider#renew', function () {
     it('calls Vault every time when renewing', function (done) {
-      const transit = new TransitProvider('KEY', 'TOKEN', {ciphertext: 'CTEXT'});
+      const transit = new TransitProvider({key: 'KEY', ciphertext: 'CTEXT'}, 'TOKEN');
 
       localVaultMock.post('/v1/transit/decrypt/KEY', {
         ciphertext: 'CTEXT'
@@ -175,7 +175,7 @@ describe('Provider/Transit', function () {
     });
 
     it('fails with an error if the key does not exist', function (done) {
-      const transit = new TransitProvider('INVALID-KEY', 'TOKEN', {ciphertext: 'CTEXT'});
+      const transit = new TransitProvider({key: 'INVALID-KEY', ciphertext: 'CTEXT'}, 'TOKEN');
 
       localVaultMock.post('/v1/transit/decrypt/INVALID-KEY', {
         ciphertext: 'CTEXT'

--- a/test/provider-transit.js
+++ b/test/provider-transit.js
@@ -30,8 +30,6 @@ function createVaultMock(options) {
     .get('/v1/sys/mounts')
     .reply(STATUS_CODES.OK, {'transit/': {config: {default_lease_ttl: 0, max_lease_ttl: 0}, type: 'transit'}})
     .get('/v1/sys/auth')
-    .reply(STATUS_CODES.OK, {'token/': {type: 'token'}})
-    .post('/v1/sys/mounts/transit', {type: 'transit', description: 'Transit Secrets Backend transit'})
     .reply(STATUS_CODES.OK, {'token/': {type: 'token'}});
 }
 

--- a/test/provider-transit.js
+++ b/test/provider-transit.js
@@ -100,9 +100,7 @@ describe('Provider/Transit', function () {
         plaintext: 'PTEXT'
       });
 
-      transit._client.prepare(transit._token)
-      .then(() => transit._client.mountTransit({token: transit._token}))
-      .then(() => transit.initialize())
+      transit.initialize()
       .then((retrievedPlaintext) => {
         should(retrievedPlaintext).eql({
           plaintext: 'PTEXT'

--- a/test/provider-transit.js
+++ b/test/provider-transit.js
@@ -8,28 +8,36 @@ const should = require('should');
 
 describe('Provider/Transit', function () {
   describe('TransitProvider#constructor', function () {
-    it('throws an IllegalValueError if the key is not provided', function () {
-      should.throws(() => {
-        return new TransitProvider('', 'TOKEN', {ciphertext: 'CTEXT'});
-      }, preconditions.IllegalValueError);
+    it('requires key be provided', function () {
+      [null, undefined, ''].forEach(function (value) {
+        should.throws(() => {
+          return new TransitProvider(value, 'TOKEN', {ciphertext: 'CTEXT'});
+        }, preconditions.IllegalValueError, `invalid "key" argument: ${value}`);
+      });
     });
 
-    it('throws an IllegalValueError if the token is not provided', function () {
-      should.throws(() => {
-        return new TransitProvider('KEY', '', {ciphertext: 'CTEXT'});
-      }, preconditions.IllegalValueError);
+    it('requires token be provided', function () {
+      [null, undefined, ''].forEach(function (value) {
+        should.throws(() => {
+          return new TransitProvider('KEY', value, {ciphertext: 'CTEXT'});
+        }, preconditions.IllegalValueError, `invalid "token" argument: ${value}`);
+      });
     });
 
-    it('throws an IllegalValueError if the parameters are not provided', function () {
-      should.throws(() => {
-        return new TransitProvider('KEY', '', null);
-      }, preconditions.IllegalValueError);
+    it('requires parameters be provided', function () {
+      [null, undefined, ''].forEach(function (value) {
+        should.throws(() => {
+          return new TransitProvider('KEY', 'TOKEN', value);
+        }, preconditions.IllegalValueError, `invalid "parameters" argument: ${value}`);
+      });
     });
 
-    it('throws an IllegalValueError if parameters.ciphertext is not provided', function () {
-      should.throws(() => {
-        return new TransitProvider('KEY', '', {plaintext: 'PTEXT'});
-      }, preconditions.IllegalValueError);
+    it('requires parameters.ciphertext be provided', function () {
+      [null, undefined, ''].forEach(function (value) {
+        should.throws(() => {
+          return new TransitProvider('KEY', 'TOKEN', {ciphertext: value});
+        }, preconditions.IllegalValueError, `invalid "parameters.ciphertext" argument: ${value}`);
+      });
     });
   });
 });


### PR DESCRIPTION
This fixes #57. There's now a `TransitProvider` class that can handle decrypting secrets from Vault. Note that this does not wire the provider into the `/v1/transit/default` API. That will happen in a separate pull request.