### PR TITLE
Separate cookbook and build gem dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ node_modules
 .builderator/
 
 cookbook/metadata.json
+
+# Build artifacts
+*.tar.gz
+*.tgz
+npm-shrinkwrap.json

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'builderator', '~> 1.0'
-gem "octokit", "~> 4.0"
+gem 'octokit', '~> 4.0'
 gem 'fpm', '~> 1.6'
+
+group :cookbook do
+  gem 'builderator', '~> 1.0'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -53,12 +53,12 @@ def config_dir
   ::File.join(install_dir, 'config')
 end
 
-def base_dir
-  @base_dir ||= File.dirname(File.expand_path(__FILE__))
-end
-
 def pkg_dir
   ::File.join(base_dir, 'pkg')
+end
+
+def base_dir
+  @base_dir ||= File.dirname(File.expand_path(__FILE__))
 end
 
 def github_client
@@ -97,7 +97,6 @@ task :tokend_source => [:install] do
   end
   cp ::File.join(base_dir, 'config', 'defaults.json'), ::File.join(base_dir, config_dir)
 end
-
 
 task :chdir_pkg => [:package_dirs] do
   cd pkg_dir


### PR DESCRIPTION
This PR defines a `:cookbook` group so we can use the `--without` flag when we want to `bundle install` and not have to wait forever for `dep-selector-libgecode` to install.