### PR TITLE
Make Rakefile great again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ node_modules
 .builderator/
 
 cookbook/metadata.json
+
+# Build artifacts
+*.tar.gz
+*.tgz
+npm-shrinkwrap.json

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'builderator', '~> 1.0'
-gem "octokit", "~> 4.0"
+gem 'octokit', '~> 4.0'
 gem 'fpm', '~> 1.6'
+
+group :cookbook do
+  gem 'builderator', '~> 1.0'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 source 'https://rubygems.org'
 
-gem 'octokit', '~> 4.0'
+gem 'rake', '~> 10.5'
+gem 'aws-sdk', '~> 2.2'
 gem 'fpm', '~> 1.6'
+gem 'octokit', '~> 4.0'
 
 group :cookbook do
   gem 'builderator', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,7 @@ GEM
     plist (3.2.0)
     proxifier (1.0.3)
     rack (1.6.4)
+    rake (10.5.0)
     retryable (2.0.4)
     ridley (4.6.1)
       addressable
@@ -259,9 +260,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk (~> 2.2)
   builderator (~> 1.0)
   fpm (~> 1.6)
   octokit (~> 4.0)
+  rake (~> 10.5)
 
 BUNDLED WITH
    1.12.5

--- a/Rakefile
+++ b/Rakefile
@@ -125,7 +125,8 @@ task :deb => [:chdir_pkg, :source] do
   sh command
 end
 
-task :upload_packages => [:deb] do
+task :upload_packages do
+  cd pkg_dir
   mkdir 'copy_to_s3'
   deb = Dir["#{name}_#{version}_*.deb"].first
   cp deb, 'copy_to_s3/'
@@ -137,7 +138,7 @@ task :upload_packages => [:deb] do
 end
 
 desc "Release #{name} and prepare to create a release on github.com"
-task :release => [:package] do
+task :release do
   puts
   puts "Create a new #{version} release on github.com and upload the #{name} tarball"
   puts 'You can find directions here: https://github.com/blog/1547-release-your-software'
@@ -178,3 +179,4 @@ CLEAN.include '**/.DS_Store'
 CLEAN.include 'node_modules/'
 
 task :default => [:clean, :package, :release]
+task :upload => [:clean, :package, :upload_packages]

--- a/Rakefile
+++ b/Rakefile
@@ -137,12 +137,12 @@ task :upload_packages => [:deb] do
 end
 
 desc "Release #{name} and prepare to create a release on github.com"
-task :release do
+task :release => [:package] do
   puts
   puts "Create a new #{version} release on github.com and upload the #{name} tarball"
   puts 'You can find directions here: https://github.com/blog/1547-release-your-software'
-  puts
   puts 'Make sure you add release notes!'
+
   cp ::File.join(base_dir, "#{name}-#{version}.tgz"), pkg_dir
 
   begin
@@ -167,6 +167,9 @@ task :release do
   compare_url = "#{github_repo.url}/compare/#{latest_release.name}...#{release.name}"
   puts "You can find a diff between this release and the previous one here: #{compare_url}"
 end
+
+desc "Package #{name}"
+task :package => [:install, :shrinkwrap, :pack, :deb]
 
 CLEAN.include 'npm-shrinkwrap.json'
 CLEAN.include "#{name}-*.tgz"

--- a/Rakefile
+++ b/Rakefile
@@ -53,12 +53,12 @@ def config_dir
   ::File.join(install_dir, 'config')
 end
 
-def base_dir
-  @base_dir ||= File.dirname(File.expand_path(__FILE__))
-end
-
 def pkg_dir
   ::File.join(base_dir, 'pkg')
+end
+
+def base_dir
+  @base_dir ||= File.dirname(File.expand_path(__FILE__))
 end
 
 def github_client
@@ -97,7 +97,6 @@ task :tokend_source => [:install] do
   end
   cp ::File.join(base_dir, 'config', 'defaults.json'), ::File.join(base_dir, config_dir)
 end
-
 
 task :chdir_pkg => [:package_dirs] do
   cd pkg_dir

--- a/Rakefile
+++ b/Rakefile
@@ -94,7 +94,7 @@ task :package_dirs do
   mkdir_p ::File.join(base_dir, config_dir)
 end
 
-task :tokend_source => [:install] do
+task :source => [:install] do
   ['bin/', 'lib/', 'node_modules/', 'LICENSE', 'package.json'].each do |src|
     cp_r ::File.join(base_dir, src), ::File.join(base_dir, install_dir)
   end
@@ -105,7 +105,7 @@ task :chdir_pkg => [:package_dirs] do
   cd pkg_dir
 end
 
-task :deb => [:chdir_pkg, :tokend_source] do
+task :deb => [:chdir_pkg, :source] do
   command = [
     'bundle',
     'exec',


### PR DESCRIPTION
This PR makes Rakefile tasks more consistent across the Spectre services. It was branched off of [gem-groups](https://github.com/rapid7/tokend/tree/gem-groups) but while it could be merged now, we should wait until #63 is merged just to make sure the intent of both pull requests is respected.