### PR TITLE
Fix: POST to correct Warden endpoint

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -42,7 +42,8 @@ Config.required([
   'vault:port',
   'vault:token_ttl',
   'warden:host',
-  'warden:port'
+  'warden:port',
+  'warden:path'
 ]);
 
 global.Log = Logger.attach(Config.get('log:level'));

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -14,7 +14,6 @@
     "json": true
   },
   "warden": {
-    "host": "127.0.0.1",
     "port": 8705,
     "path": "/v1/authenticate"
   }

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -12,5 +12,10 @@
   "log": {
     "level": "INFO",
     "json": true
+  },
+  "warden": {
+    "host": "127.0.0.1",
+    "port": 8705,
+    "path": "/v1/authenticate"
   }
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -8,10 +8,6 @@
   "metadata": {
     "host": "127.0.0.1:8900"
   },
-  "warden": {
-    "host": "127.0.0.1",
-    "port": 3000
-  },
   "log": {
     "level": "INFO",
     "json": false

--- a/config/dev.json
+++ b/config/dev.json
@@ -8,6 +8,9 @@
   "metadata": {
     "host": "127.0.0.1:8900"
   },
+  "warden": {
+    "host": "127.0.0.1"
+  },
   "log": {
     "level": "INFO",
     "json": false

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -31,7 +31,8 @@ specified in order for Tokend to run.
   },
   "warden": {
     "host": "127.0.0.1",
-    "port": 3000
+    "port": 3000,
+    "path": "/v1/authenticate"
   }
 }
 ```
@@ -88,6 +89,7 @@ exposed for development purposes.
 
 	* `host` - The hostname for Warden.
   * `port` - The port for Warden.
+  * `path` - The Warden endpoint to authenticate against.
 
 * `service` - These settings control the HTTP API.
 

--- a/lib/providers/token.js
+++ b/lib/providers/token.js
@@ -25,6 +25,7 @@ const DEFAULT_METADATA_HOST = Config.get('metadata:host');
 // Default Warden connection options
 const DEFAULT_WARDEN_HOST = Config.get('warden:host');
 const DEFAULT_WARDEN_PORT = Config.get('warden:port');
+const DEFAULT_WARDEN_PATH = Config.get('warden:path');
 
 const VAULT_TOKEN_TTL = Config.get('vault:token_ttl');
 
@@ -98,7 +99,8 @@ class TokenProvider {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       hostname: DEFAULT_WARDEN_HOST,
-      port: DEFAULT_WARDEN_PORT
+      port: DEFAULT_WARDEN_PORT,
+      path: DEFAULT_WARDEN_PATH
     };
 
     if (opts.warden) {


### PR DESCRIPTION
This PR resolves #71 by adding a `path` option to the Warden config and moving the Warden config options into `defaults.json`.