### PR TITLE
Removed token_ttl config option.

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -40,7 +40,6 @@ Config.defaults(require('../config/defaults.json'));
 Config.required([
   'vault:host',
   'vault:port',
-  'vault:token_ttl',
   'warden:host',
   'warden:port',
   'warden:path'

--- a/config/dev.json
+++ b/config/dev.json
@@ -2,8 +2,7 @@
   "vault": {
     "host": "127.0.0.1",
     "port": 8200,
-    "tls": false,
-    "token_ttl": "1m"
+    "tls": false
   },
   "metadata": {
     "host": "127.0.0.1:8900"

--- a/lib/providers/token.js
+++ b/lib/providers/token.js
@@ -27,8 +27,6 @@ const DEFAULT_WARDEN_HOST = Config.get('warden:host');
 const DEFAULT_WARDEN_PORT = Config.get('warden:port');
 const DEFAULT_WARDEN_PATH = Config.get('warden:path');
 
-const VAULT_TOKEN_TTL = Config.get('vault:token_ttl');
-
 class TokenProvider {
   /**
    * Constructor
@@ -158,8 +156,7 @@ class TokenProvider {
     return this._client.prepare(this.token)
       .then(this._client.renewToken.bind(this._client, {
         id: this.token,
-        token: this.token,
-        body: {increment: VAULT_TOKEN_TTL}
+        token: this.token
       }, null))
       .then((data) => {
         this.data = {


### PR DESCRIPTION
This PR removes the `token_ttl` config option as Warden sets the TTL of tokens explicitly and Tokend uses that `lease_duration` to determine when to renew.