### PR TITLE
Clean up HTTP API tests

### DIFF
--- a/test/utils/http.js
+++ b/test/utils/http.js
@@ -108,7 +108,7 @@ class HttpTestUtils {
     }
 
     if (code === STATUS_CODES.OK || code === STATUS_CODES.BAD_REQUEST) {
-      r = r.expect('Content-Type', /json/);
+      r = r.expect('Content-Type', 'application/json; charset=utf-8');
     }
 
     return r


### PR DESCRIPTION
This PR cleans up some of the HTTP API tests to make them easier to work with. This is in advance of adding some better middleware flow control for HTTP error handling so we can do a better job logging them.