### PR TITLE
Added header verification middleware

### DIFF
--- a/lib/control/util/index.js
+++ b/lib/control/util/index.js
@@ -22,7 +22,12 @@ const Err = (err, req, res, next) => { // eslint-disable-line no-unused-vars
 
   // Include response headers if it's a HTTP error
   if (err.response) {
-    error.error.headers = err.response.headers;
+    const defaultHeaders = {
+      Accept: 'application/json',
+      'Accept-Charset': 'utf-8'
+    };
+
+    error.error.headers = Object.assign(defaultHeaders, err.response.headers);
   }
 
   res.status(statusCode);
@@ -40,11 +45,6 @@ const VerifyHeader = (header, value) => ((req, res, next) => {
   const err = new TypeError(`${header} must be \`${value}\`.`);
 
   err.statusCode = STATUS_CODES.BAD_REQUEST;
-  err.response = {};
-  err.response.headers = {
-    Accept: 'application/json',
-    'Accept-Charset': 'utf-8'
-  };
   throw err;
 });
 

--- a/lib/control/util/index.js
+++ b/lib/control/util/index.js
@@ -35,9 +35,9 @@ const Err = (err, req, res, next) => { // eslint-disable-line no-unused-vars
 };
 
 const VerifyHeader = (header, value) => ((req, res, next) => {
-  const h = req.headers[header];
+  const h = req.headers[header.toLowerCase()];
 
-  if (h && h.toLowerCase() === value) {
+  if (h && h === value) {
     return next();
   }
 

--- a/lib/control/util/index.js
+++ b/lib/control/util/index.js
@@ -29,7 +29,26 @@ const Err = (err, req, res, next) => { // eslint-disable-line no-unused-vars
   res.json(error);
 };
 
+const VerifyHeader = (header, value) => ((req, res, next) => {
+  const h = req.headers[header];
+
+  if (h && h.toLowerCase() === value) {
+    return next();
+  }
+
+  // Throw exception here to unearth issues
+  const err = new TypeError(`${header} must be \`${value}\`.`);
+
+  err.statusCode = STATUS_CODES.BAD_REQUEST;
+  err.response = {};
+  err.response.headers = {
+    Accept: 'application/json'
+  };
+  throw err;
+});
+
 module.exports = {
   Handlers,
-  Err
+  Err,
+  VerifyHeader
 };

--- a/lib/control/util/index.js
+++ b/lib/control/util/index.js
@@ -42,7 +42,8 @@ const VerifyHeader = (header, value) => ((req, res, next) => {
   err.statusCode = STATUS_CODES.BAD_REQUEST;
   err.response = {};
   err.response.headers = {
-    Accept: 'application/json'
+    Accept: 'application/json',
+    'Accept-Charset': 'utf-8'
   };
   throw err;
 });

--- a/lib/control/util/index.js
+++ b/lib/control/util/index.js
@@ -34,22 +34,32 @@ const Err = (err, req, res, next) => { // eslint-disable-line no-unused-vars
   res.json(error);
 };
 
-const VerifyHeader = (header, value) => ((req, res, next) => {
-  const h = req.headers[header.toLowerCase()];
-
-  if (h && h === value) {
+const VerifyHeaders = (methods, headers) => ((req, res, next) => {
+  if (methods.indexOf(req.method) === -1) {
     return next();
   }
 
-  // Throw exception here to unearth issues
-  const err = new TypeError(`${header} must be \`${value}\`.`);
+  for (const header in headers) {
+    if (!headers.hasOwnProperty(header)) {
+      continue;
+    }
 
-  err.statusCode = STATUS_CODES.BAD_REQUEST;
-  throw err;
+    const h = req.headers[header.toLowerCase()];
+
+    if (!h || h !== headers[header]) {
+      // Throw exception here to unearth issues
+      const err = new TypeError(`${header} must be \`${headers[header]}\`.`);
+
+      err.statusCode = STATUS_CODES.BAD_REQUEST;
+      throw err;
+    }
+  }
+
+  next();
 });
 
 module.exports = {
   Handlers,
   Err,
-  VerifyHeader
+  VerifyHeaders
 };

--- a/lib/control/v1/index.js
+++ b/lib/control/v1/index.js
@@ -2,10 +2,12 @@
 
 const Handlers = require('../util').Handlers;
 const Err = require('../util').Err;
-const VerifyHeader = require('../util').VerifyHeader;
+const VerifyHeaders = require('../util').VerifyHeaders;
 
 exports.attach = function(app, storage) {
-  app.use(VerifyHeader('Content-Type', 'application/json; charset=utf-8'));
+  app.use(VerifyHeaders(['POST', 'PUT'], {
+    'Content-Type': 'application/json; charset=utf-8'
+  }));
 
   app.get('/v1/health', require('./health'));
   app.get('/v1/token/default', require('./token')(storage));

--- a/lib/control/v1/index.js
+++ b/lib/control/v1/index.js
@@ -2,8 +2,11 @@
 
 const Handlers = require('../util').Handlers;
 const Err = require('../util').Err;
+const VerifyHeader = require('../util').VerifyHeader;
 
 exports.attach = function(app, storage) {
+  app.use(VerifyHeader('Content-Type', 'application/json; charset=utf-8'));
+
   app.get('/v1/health', require('./health'));
   app.get('/v1/token/default', require('./token')(storage));
 

--- a/test/http-server-v1.js
+++ b/test/http-server-v1.js
@@ -88,7 +88,7 @@ describe('v1 API', function() {
     const endpoint = '/v1/health';
 
     it('accepts GET requests', function() {
-      return util.acceptRequest(endpoint, 'GET', {}, requiredHeaders);
+      return util.acceptRequest(endpoint, 'GET', {}, {});
     });
 
     it('rejects all other request types', function() {
@@ -96,7 +96,7 @@ describe('v1 API', function() {
     });
 
     it('returns the service health', function(done) {
-      util.testEndpointResponse(endpoint, 'GET', STATUS_CODES.OK, {}, requiredHeaders, (err, res) => {
+      util.testEndpointResponse(endpoint, 'GET', STATUS_CODES.OK, {}, {}, (err, res) => {
         res.body.should.have.property('uptime');
         res.body.should.have.property('status');
         res.body.should.have.property('version');
@@ -109,7 +109,7 @@ describe('v1 API', function() {
     const endpoint = '/v1/token/default';
 
     it('accepts GET requests', function() {
-      return util.acceptRequest(endpoint, 'GET', {}, requiredHeaders);
+      return util.acceptRequest(endpoint, 'GET', {}, {});
     });
 
     it('rejects all other request types', function() {
@@ -121,7 +121,7 @@ describe('v1 API', function() {
       server = makeServer(new StorageServiceMockWithTokenResponse());
       util = new HttpTestUtils(server);
 
-      util.testEndpointResponse(endpoint, 'GET', STATUS_CODES.OK, {}, requiredHeaders, (err, res) => {
+      util.testEndpointResponse(endpoint, 'GET', STATUS_CODES.OK, {}, {}, (err, res) => {
         res.body.should.eql('token');
         done();
       });
@@ -132,7 +132,7 @@ describe('v1 API', function() {
       server = makeServer(new StorageServiceMockWithError());
       util = new HttpTestUtils(server);
 
-      util.testEndpointResponse(endpoint, 'GET', STATUS_CODES.OK, {}, requiredHeaders, (err, res) => {
+      util.testEndpointResponse(endpoint, 'GET', STATUS_CODES.OK, {}, {}, (err, res) => {
         res.body.should.eql({
           error: {
             message: 'Funky looking error message',
@@ -152,7 +152,7 @@ describe('v1 API', function() {
       const endpoint = el.endpoint;
 
       it('accepts GET requests', function() {
-        return util.acceptRequest(endpoint, 'GET', {}, requiredHeaders);
+        return util.acceptRequest(endpoint, 'GET', {}, {});
       });
 
       it('rejects all other request types', function() {
@@ -164,7 +164,7 @@ describe('v1 API', function() {
         server = makeServer(new StorageServiceMockWithSecretResponse());
         util = new HttpTestUtils(server);
 
-        util.testEndpointResponse(endpoint, 'GET', STATUS_CODES.OK, {}, requiredHeaders, (err, res) => {
+        util.testEndpointResponse(endpoint, 'GET', STATUS_CODES.OK, {}, {}, (err, res) => {
           res.body.should.eql({
             username: 'bob',
             password: 'my-awesome-password123'
@@ -178,7 +178,7 @@ describe('v1 API', function() {
         server = makeServer(new StorageServiceMockWithError());
         util = new HttpTestUtils(server);
 
-        util.testEndpointResponse(endpoint, 'GET', STATUS_CODES.OK, {}, requiredHeaders, (err, res) => {
+        util.testEndpointResponse(endpoint, 'GET', STATUS_CODES.OK, {}, {}, (err, res) => {
           res.body.should.eql({
             error: {
               message: 'Funky looking error message',

--- a/test/http-server-v1.js
+++ b/test/http-server-v1.js
@@ -73,7 +73,7 @@ describe('v1 API', function() {
   });
 
   it(`returns a ${STATUS_CODES.BAD_REQUEST} if 'Content-Type: application/json' is not specified`, function(done) {
-    util.testEndpointResponse('/v1/health', 'GET', STATUS_CODES.BAD_REQUEST, {}, {}, (err, res) => {
+    util.testEndpointResponse('/v1/transit/default/decrypt', 'POST', STATUS_CODES.BAD_REQUEST, JSON.stringify({}), {}, (err, res) => {
       res.statusCode.should.equal(STATUS_CODES.BAD_REQUEST);
       res.body.should.have.property('error');
       res.body.error.should.have.property('name');


### PR DESCRIPTION
This PR adds a middleware to verify (and require) headers. This is required as `body-parser` will not attempt to parse the request body as JSON unless `Content-Type: application/json` is specified. With this middleware, we can short-circuit the request and error out early, saving a round trip to the EC2 Metadata Service, Warden, and Vault.