### PR TITLE
Add correlation ID

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,14 @@
+# According to https://docs.travis-ci.com/user/ci-environment,
+# `sudo: required` must be set to use `dist: trusty`
+dist: trusty
+sudo: required
+
 language: node_js
-sudo: false
+addons:
+  apt:
+    packages:
+      - build-essential
+      - uuid-dev
 script:
   - npm test
   - npm run lint

--- a/lib/control/v1/credential.js
+++ b/lib/control/v1/credential.js
@@ -15,6 +15,11 @@ function Credential(storage) {
 
     storage.lookup(token, `${mount}/${role}`, CredentialProvider)
       .then((result) => {
+        if (result != null && result.hasOwnProperty('correlation_id')) { // eslint-disable-line eqeqeq
+          res.correlationId = result.correlation_id;
+          delete result.correlation_id;
+        }
+
         res.json(result);
       }).catch(next);
   };

--- a/lib/control/v1/cubbyhole.js
+++ b/lib/control/v1/cubbyhole.js
@@ -14,6 +14,11 @@ function CubbyHole(storage) {
 
     storage.lookup(token, path, CubbyHoleProvider)
       .then((result) => {
+        if (result != null && result.hasOwnProperty('correlation_id')) { // eslint-disable-line eqeqeq
+          res.correlationId = result.correlation_id;
+          delete result.correlation_id;
+        }
+
         res.json(result);
       }).catch(next);
   };

--- a/lib/control/v1/secret.js
+++ b/lib/control/v1/secret.js
@@ -14,6 +14,11 @@ function Secret(storage) {
 
     storage.lookup(token, path, SecretProvider)
       .then((result) => {
+        if (result != null && result.hasOwnProperty('correlation_id')) { // eslint-disable-line eqeqeq
+          res.correlationId = result.correlation_id;
+          delete result.correlation_id;
+        }
+
         res.json(result);
       }).catch(next);
   };

--- a/lib/control/v1/token.js
+++ b/lib/control/v1/token.js
@@ -11,6 +11,11 @@ function Token(storage) {
   return (req, res, next) => {
     storage.lookup('default', 'default', TokenProvider)
       .then((result) => {
+        if (result != null && result.hasOwnProperty('correlation_id')) { // eslint-disable-line eqeqeq
+          res.correlationId = result.correlation_id;
+          delete result.correlation_id;
+        }
+
         res.json(result);
       }).catch(next);
   };

--- a/lib/control/v1/transit.js
+++ b/lib/control/v1/transit.js
@@ -15,6 +15,12 @@ function Transit(storage) {
         if (result != null && result.hasOwnProperty('plaintext')) { // eslint-disable-line eqeqeq
           result.plaintext = Buffer.from(result.plaintext, 'base64').toString();
         }
+
+        if (result != null && result.hasOwnProperty('correlation_id')) { // eslint-disable-line eqeqeq
+          res.correlationId = result.correlation_id;
+          delete result.correlation_id;
+        }
+
         res.json(result);
       })
       .catch(next);

--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -28,7 +28,7 @@ class LeaseManager extends EventEmitter {
     this.provider = provider;
     this.name = name;
     this.error = null;
-    this.correlationId = Correlation.create();
+    this.correlation_id = Correlation.create();
 
     this.on('renewed', (result) => {
       this.lease_duration = result.lease_duration;

--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -2,6 +2,7 @@
 
 const EventEmitter = require('events').EventEmitter;
 const STATUS = require('./utils/status');
+const Correlation = require('./utils/correlation');
 const VAULT_TOKEN_TTL = Config.get('vault:token_ttl');
 
 /**
@@ -27,6 +28,7 @@ class LeaseManager extends EventEmitter {
     this.provider = provider;
     this.name = name;
     this.error = null;
+    this.correlationId = Correlation.create();
 
     this.on('renewed', (result) => {
       this.lease_duration = result.lease_duration;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -53,7 +53,17 @@ function RequestLogger(logger, level) {
     expressFormat: false,
     msg: '{{req.method}} {{req.url}} {{res.statusCode}} {{res.responseTime}}ms',
     level: logLevel,
-    baseMeta: {sourceName: 'request'}
+    baseMeta: {sourceName: 'request'},
+    meta: true,
+    dynamicMeta: (req, res) => {
+      if (res.correlationId) {
+        return {
+          correlationId: res.correlationId
+        };
+      }
+
+      return {};
+    }
   });
 }
 

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -148,7 +148,7 @@ class StorageService {
     const manager = new LeaseManager(provider, secretID);
 
     StorageService.setEvents(manager);
-    StorageService.logManagerEvent('DEBUG', 'Created LeaseManager.', manager);
+    StorageService.logManagerEvent('INFO', 'Created LeaseManager.', manager);
 
     // Don't cache providers that can't be renewed
     if (manager.renewable) {

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -69,19 +69,22 @@ class StorageService {
 
     return this._getLeaseManager(token, secret, ProviderType).then((m) => {
       manager = m;
+      const correlationData = {
+        correlation_id: manager.correlation_id
+      };
 
       if (manager.status === STATUS.READY) {
         StorageService.logManagerEvent('INFO', 'Manager was able to lookup a secret.', manager);
 
         // LeaseManager is ready, immediately resolve with data
-        return manager.data;
+        return Object.assign(correlationData, manager.data);
       }
 
       // Queue the promise states with a timeout
       return onceWithTimeout(manager, 'ready', this.timeout).then(() => {
         StorageService.logManagerEvent('INFO', 'Manager was able to lookup a secret.', manager);
 
-        return manager.data;
+        return Object.assign(correlationData, manager.data);
       })
       .catch((err) => {
         StorageService.logManagerEvent('ERROR', err, manager);

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -167,7 +167,8 @@ class StorageService {
     const meta = {
       provider: type,
       status: manager.status,
-      lease_duration: manager.lease_duration
+      lease_duration: manager.lease_duration,
+      correlation_id: manager.correlation_id
     };
 
     Log.log(level, message, meta);

--- a/lib/utils/correlation.js
+++ b/lib/utils/correlation.js
@@ -7,9 +7,5 @@ const UUID = require('node-libuuid');
  * @return {String}
  */
 exports.create = function create() {
-  const id = UUID.v4();
-
-  Log.log('INFO', `Created correlation id ${id}`);
-
-  return id;
+  return UUID.v4();
 };

--- a/lib/utils/correlation.js
+++ b/lib/utils/correlation.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const UUID = require('node-libuuid');
+
+/**
+ * Create a correlation id
+ * @return {String}
+ */
+exports.create = function create() {
+  const id = UUID.v4();
+
+  Log.log('INFO', `Created correlation id ${id}`);
+
+  return id;
+};

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "body-parser": "~1.15.2",
     "conditional": "~5.3.0",
     "express": "~4.13.4",
-    "express-winston": "~1.4.1",
+    "express-winston": "~2.1.0",
     "lodash": "~4.13.0",
     "morgan": "~1.7.0",
     "nconf": "~0.8.4",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lodash": "~4.13.0",
     "morgan": "~1.7.0",
     "nconf": "~0.8.4",
+    "node-libuuid": "~2.0.0",
     "vaulted": "~3.2.0",
     "winston": "~2.2.0",
     "yargs": "~4.7.0"

--- a/test/storage-service.js
+++ b/test/storage-service.js
@@ -15,11 +15,19 @@ const TokenProvider = require('../lib/providers/token');
 class ImmediateInitializeProvider {
 
   initialize() {
-    return Promise.resolve({data: 'SECRET'});
+    return Promise.resolve({
+      data: {
+        plaintext: 'SECRET'
+      }
+    });
   }
 
   renew() {
-    return Promise.resolve({data: 'SECRET'});
+    return Promise.resolve({
+      data: {
+        plaintext: 'SECRET'
+      }
+    });
   }
 }
 
@@ -90,12 +98,16 @@ class DelayedInitializeProvider {
 
   initialize() {
     return new Promise((resolve, reject) => {
-      setTimeout(() => resolve({data: 'SECRET'}), this.delay);
+      setTimeout(() => resolve({data: {
+        plaintext: 'SECRET'
+      }}), this.delay);
     });
   }
 
   renew() {
-    return Promise.resolve({data: 'SECRET'});
+    return Promise.resolve({data: {
+      plaintext: 'SECRET'
+    }});
   }
 }
 
@@ -163,7 +175,8 @@ describe('StorageService', function() {
 
       return manager.initialize().then(() => storage.lookup('default', 'test', ImmediateInitializeProvider)
         .then((data) => {
-          should(data).eql('SECRET');
+          should(data).containEql({plaintext: 'SECRET'});
+          should(data).have.keys('correlation_id', 'plaintext');
         }));
     });
 
@@ -199,7 +212,8 @@ describe('StorageService', function() {
 
       let numTimesToBeCalled = 2;
       const callback = (data) => {
-        should(data).eql('SECRET');
+        should(data).containEql({plaintext: 'SECRET'});
+        should(data).have.keys('correlation_id', 'plaintext');
 
         numTimesToBeCalled--;
         if (numTimesToBeCalled === 0) {
@@ -221,7 +235,8 @@ describe('StorageService', function() {
 
       let numTimesToBeCalled = 2;
       const callback = (data) => {
-        should(data).eql('SECRET');
+        should(data).containEql({plaintext: 'SECRET'});
+        should(data).have.key('correlation_id', 'plaintext');
 
         numTimesToBeCalled--;
         if (numTimesToBeCalled === 0) {
@@ -275,7 +290,8 @@ describe('StorageService', function() {
       return storage.lookup('default', {key: 'KEY', ciphertext: 'CTEXT'}, NonRenewingProvider)
       .then((result) => {
         storage._managers.size.should.equal(1);
-        result.should.eql({plaintext: 'PTEXT'});
+        result.should.containEql({plaintext: 'PTEXT'});
+        result.should.have.keys('correlation_id', 'plaintext');
       });
     });
 
@@ -285,7 +301,8 @@ describe('StorageService', function() {
       return storage.lookup('default', {key: 'KEY', ciphertext: 'CTEXT'}, DelayedNonRenewingProvider)
       .then((result) => {
         storage._managers.size.should.equal(1);
-        result.should.eql({plaintext: 'PTEXT'});
+        result.should.containEql({plaintext: 'PTEXT'});
+        result.should.have.keys('correlation_id', 'plaintext');
       });
     });
   });


### PR DESCRIPTION
This PR adds a `correlation_id` for every `LeaseManager` instance for logging so we can trace actions through the system. It also adds the same `correlation_id` to the `Express#response` object so we can use `express-winston` to map the request -> response cycle to a given `LeaseManager`'s actions.