### PR TITLE
Parse token expiration data from warden

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -48,7 +48,9 @@ Config.required([
 global.Log = Logger.attach(Config.get('log:level'));
 
 // Add request logging middleware
-app.use(Logger.requests(Log, Config.get('log:level')));
+if (Config.get('log:requests')) {
+  app.use(Logger.requests(Log, Config.get('log:level')));
+}
 
 // Add middleware for paring JSON requests
 app.use(BodyParser.json());

--- a/bin/server.js
+++ b/bin/server.js
@@ -39,7 +39,7 @@ Config.defaults(require('../config/defaults.json'));
 Config.required([
   'vault:host',
   'vault:port',
-  'vault:token_ttl',
+  'vault:token_renew_increment',
   'warden:host',
   'warden:port',
   'warden:path'

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -11,7 +11,8 @@
   },
   "log": {
     "level": "INFO",
-    "json": true
+    "json": true,
+    "requests": true
   },
   "warden": {
     "port": 8705,

--- a/config/dev.json
+++ b/config/dev.json
@@ -3,7 +3,7 @@
     "host": "127.0.0.1",
     "port": 8200,
     "tls": false,
-    "token_ttl": 60
+    "token_renew_increment": 60
   },
   "metadata": {
     "host": "127.0.0.1:8900"

--- a/config/dev.json
+++ b/config/dev.json
@@ -12,7 +12,8 @@
     "host": "127.0.0.1"
   },
   "log": {
-    "level": "INFO",
-    "json": false
+    "level": "DEBUG",
+    "json": false,
+    "requests": false
   }
 }

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -27,7 +27,7 @@ specified in order for Tokend to run.
   "vault": {
     "host": "127.0.0.1",
     "port": 8200,
-    "token_ttl": 60
+    "token_renew_increment": 60
   },
   "warden": {
     "host": "127.0.0.1",
@@ -70,7 +70,7 @@ This is the default configuration for Tokend, which you can find in
 	* `host` - The HTTP address of the Vault server. Defaults to `127.0.0.1`.
 	* `port` - The HTTP port of the Vault server. Defaults to `8200`.
 	* `tls` - Whether Vault should use TLS. Defaults to `true`.
-	* `token_ttl` - The TTL (time to live) of Vault tokens. This maps directly to Vault's [`default_lease_ttl`][default_lease_ttl] setting.
+	* `token_renew_increment` - The number of seconds that Tokend should attempt to renew the token for. Note: this setting may be ignored by Vault if Tokend attempts to extend the lifetime of the token beyond its [`default_lease_ttl`][default_lease_ttl] or [`max_lease_ttl`][max_lease_ttl].
 
 * `metadata` - This specifies settings for the [EC2 Metadata Service][ec2-metadata-service]
 
@@ -116,5 +116,6 @@ exposed for development purposes.
 [config-path]: ../../config/defaults.json
 [Vault]: https://www.vaultproject.io/
 [default_lease_ttl]: https://www.vaultproject.io/docs/config/#default_lease_ttl
+[max_lease_ttl]: https://www.vaultproject.io/docs/config/#max_lease_ttl
 [ec2-metadata-service]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
 [Warden]: https://github.com/rapid7/warden

--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -3,7 +3,7 @@
 const EventEmitter = require('events').EventEmitter;
 const STATUS = require('./utils/status');
 const Correlation = require('./utils/correlation');
-const VAULT_TOKEN_TTL = Config.get('vault:token_renew_increment');
+const VAULT_TOKEN_RENEW_INCREMENT = Config.get('vault:token_renew_increment');
 
 /**
  * The LeaseManager maintains state about a token or secret. It leverages a
@@ -14,14 +14,10 @@ class LeaseManager extends EventEmitter {
    * Create a new instance of a LeaseManager with the given SecretProvider
    * @param {TokenProvider|GenericProvider} provider
    * @param {string} name
-   * @param {Object} options
    */
-  constructor(provider, name, options) {
+  constructor(provider, name) {
     super();
 
-    const opts = options || {};
-
-    this._token_ttl = (opts.token_ttl) ? Number(opts.token_ttl) : VAULT_TOKEN_TTL;
     this.status = STATUS.PENDING;
     this.data = null;
     this.lease_duration = 0;

--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -68,6 +68,14 @@ class LeaseManager extends EventEmitter {
   }
 
   /**
+   * Flag to determine if the provider expires
+   * @return {boolean}
+   */
+  get expires() {
+    return !!this.provider && !!this.provider.expiration_time && !!this.provider.creation_time;
+  }
+
+  /**
    * Initialize the SecretProvider
    *
    * @returns {Promise}
@@ -158,7 +166,7 @@ class LeaseManager extends EventEmitter {
         const elapsed = Date.now() - start;
 
         this.emit('renewed', result);
-        if (this._isExpiring(elapsed)) {
+        if (this.expires && this._isExpiring(elapsed)) {
           this.emit('invalidate');
         } else {
           this._timeout = this._calculateTimeout();

--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -3,7 +3,7 @@
 const EventEmitter = require('events').EventEmitter;
 const STATUS = require('./utils/status');
 const Correlation = require('./utils/correlation');
-const VAULT_TOKEN_TTL = Config.get('vault:token_ttl');
+const VAULT_TOKEN_TTL = Config.get('vault:token_renew_increment');
 
 /**
  * The LeaseManager maintains state about a token or secret. It leverages a

--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -105,7 +105,30 @@ class LeaseManager extends EventEmitter {
    * @private
    */
   _calculateTimeout() {
-    return Math.floor(this.lease_duration / 2) * 1000; // eslint-disable-line rapid7/static-magic-numbers
+    const timeout = (this.lease_duration >= VAULT_TOKEN_RENEW_INCREMENT) ?
+        VAULT_TOKEN_RENEW_INCREMENT :
+        this.lease_duration;
+
+    return Math.floor(timeout / 2) * 1000; // eslint-disable-line rapid7/static-magic-numbers
+  }
+
+  /**
+   * Calculate whether a LeaseManager's Provider is approaching expiration
+   * @param {number} elapsed
+   * @return {boolean}
+   * @private
+   */
+  _isExpiring(elapsed) {
+    const token_ttl_expiration = this.provider.creation_time + elapsed + (VAULT_TOKEN_RENEW_INCREMENT * 1000);
+
+    Log.log('DEBUG', {
+      lease_duration: this.lease_duration,
+      timeout: this._timeout,
+      token_ttl_expiration: new Date(token_ttl_expiration),
+      token_expiration: new Date(this.provider.expiration_time)
+    });
+
+    return new Date(token_ttl_expiration) >= new Date(this.provider.expiration_time);
   }
 
   /**
@@ -128,15 +151,20 @@ class LeaseManager extends EventEmitter {
 
     this._timer = true;
     this._timeout = this._calculateTimeout();
+    const start = Date.now();
 
     setImmediate(function renew() {
       this.provider.renew().then((result) => {
-        this.emit('renewed', result);
+        const elapsed = Date.now() - start;
 
-        if ((this._token_ttl / 2) >= result.lease_duration) {
+        this.emit('renewed', result);
+        if (this._isExpiring(elapsed)) {
           this.emit('invalidate');
         } else {
           this._timeout = this._calculateTimeout();
+          Log.log('DEBUG', {
+            timeout: this._timeout
+          });
           this._timer = setTimeout(renew.bind(this), this._timeout);
         }
       }).catch((err) => {

--- a/lib/providers/token.js
+++ b/lib/providers/token.js
@@ -26,7 +26,7 @@ const DEFAULT_WARDEN_HOST = Config.get('warden:host');
 const DEFAULT_WARDEN_PORT = Config.get('warden:port');
 const DEFAULT_WARDEN_PATH = Config.get('warden:path');
 
-const VAULT_TOKEN_TTL = Config.get('vault:token_renew_increment');
+const VAULT_TOKEN_RENEW_INCREMENT = Config.get('vault:token_renew_increment');
 
 /**
  * Provider type for Vault tokens
@@ -168,7 +168,7 @@ class TokenProvider {
       .then(this._client.renewToken.bind(this._client, {
         id: this.token,
         token: this.token,
-        body: {increment: VAULT_TOKEN_TTL}
+        body: {increment: VAULT_TOKEN_RENEW_INCREMENT}
       }, null))
       .then((data) => {
         this.data = {

--- a/lib/providers/token.js
+++ b/lib/providers/token.js
@@ -114,6 +114,8 @@ class TokenProvider {
 
     this.token = null;
     this.data = null;
+    this.creation_time = null;
+    this.expiration_time = null;
 
     return this;
   }
@@ -136,6 +138,8 @@ class TokenProvider {
       .then((data) => {
         const token = data.client_token;
 
+        this.expiration_time = new Date(data.expiration_time).getTime();
+        this.creation_time = new Date(data.creation_time).getTime();
         this.token = token;
         this.data = {
           lease_id: token,

--- a/lib/providers/token.js
+++ b/lib/providers/token.js
@@ -26,7 +26,7 @@ const DEFAULT_WARDEN_HOST = Config.get('warden:host');
 const DEFAULT_WARDEN_PORT = Config.get('warden:port');
 const DEFAULT_WARDEN_PATH = Config.get('warden:path');
 
-const VAULT_TOKEN_TTL = Config.get('vault:token_ttl');
+const VAULT_TOKEN_TTL = Config.get('vault:token_renew_increment');
 
 /**
  * Provider type for Vault tokens

--- a/test/init.js
+++ b/test/init.js
@@ -9,7 +9,7 @@ const defaults = Object.assign(require('../config/defaults.json'), {
     host: '127.0.0.1',
     port: 8200,
     tls: true,
-    token_ttl: 60
+    token_renew_increment: 60
   },
   warden: {
     host: '127.0.0.1',

--- a/test/lease-manager.js
+++ b/test/lease-manager.js
@@ -135,6 +135,8 @@ class NonRenewableProvider {
  */
 class ExpiringProvider {
   constructor() {
+    this.expiration_time = new Date() + 2;
+    this.creation_time = new Date();
     this.data = {
       data: 'SECRET',
       lease_duration: 2
@@ -283,7 +285,8 @@ describe('LeaseManager#_renew', function() {
   });
 
   it('should invalidate a token that expires soon', function(done) {
-    const manager = new LeaseManager(new ExpiringProvider(), '', {token_ttl: '5'});
+    Config.set('vault:token_renew_increment', 5);
+    const manager = new LeaseManager(new ExpiringProvider(), '');
 
     manager.once('invalidate', () => {
       // Manager is set back to initial state
@@ -298,6 +301,9 @@ describe('LeaseManager#_renew', function() {
 
       // Provider data is cleared
       should(manager.provider.data).be.null();
+
+      // Reset config option
+      Config.set('vault:token_renew_increment', 60);
       done();
     });
 

--- a/test/lease-manager.js
+++ b/test/lease-manager.js
@@ -172,6 +172,10 @@ describe('LeaseManager#constructor', function() {
   it('has a default renewable flag that is false', function() {
     should(new LeaseManager().renewable).be.false();
   });
+
+  it('determines whether its provider can expire', function() {
+    should(new LeaseManager(new ExpiringProvider()).expires).be.true();
+  });
 });
 
 describe('LeaseManager#initialize', function() {
@@ -286,7 +290,7 @@ describe('LeaseManager#_renew', function() {
 
   it('should invalidate a token that expires soon', function(done) {
     Config.set('vault:token_renew_increment', 5);
-    const manager = new LeaseManager(new ExpiringProvider(), '');
+    const manager = new LeaseManager(new ExpiringProvider());
 
     manager.once('invalidate', () => {
       // Manager is set back to initial state


### PR DESCRIPTION
This PR takes the token timing information from Warden (added in https://github.com/rapid7/warden/commit/1c37b35f505677ae08fd085f13e61636673a8c97) and uses it to calculate Provider expiration.