### PR TITLE
KMS provider

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -55,9 +55,13 @@ if (Config.get('log:requests')) {
 // Retrieve the instance region and store it in the Config
 const Metadata = require('../lib/utils/metadata');
 
-Metadata.region().then((region) => {
-  Config.set('metadata:region', region);
-});
+// Check if a specific region has been set. Maybe someone
+// will want to use a key from a different region?
+if (!Config.get('metadata:region')) {
+  Metadata.region().then((region) => {
+    Config.set('metadata:region', region);
+  });
+}
 
 // Add middleware for paring JSON requests
 app.use(BodyParser.json());
@@ -79,4 +83,3 @@ server.on('error', (err) => {
 server.listen(port, host, () => {
   Log.log('INFO', `Listening on ${host}:${port}`);
 });
-

--- a/bin/server.js
+++ b/bin/server.js
@@ -52,6 +52,13 @@ if (Config.get('log:requests')) {
   app.use(Logger.requests(Log, Config.get('log:level')));
 }
 
+// Retrieve the instance region and store it in the Config
+const Metadata = require('../lib/utils/metadata');
+
+Metadata.region().then((region) => {
+  Config.set('metadata:region', region);
+});
+
 // Add middleware for paring JSON requests
 app.use(BodyParser.json());
 

--- a/bin/server.js
+++ b/bin/server.js
@@ -60,6 +60,10 @@ const Metadata = require('../lib/utils/metadata');
 if (!Config.get('kms:region')) {
   Metadata.region().then((region) => {
     Config.set('kms:region', region);
+  }).catch((err) => {
+    Log.log('ERROR', err);
+    Log.log('INFO', "Setting kms region to 'us-east-1'.");
+    Config.set('kms:region', 'us-east-1');
   });
 }
 

--- a/bin/server.js
+++ b/bin/server.js
@@ -57,9 +57,9 @@ const Metadata = require('../lib/utils/metadata');
 
 // Check if a specific region has been set. Maybe someone
 // will want to use a key from a different region?
-if (!Config.get('metadata:region')) {
+if (!Config.get('kms:region')) {
   Metadata.region().then((region) => {
-    Config.set('metadata:region', region);
+    Config.set('kms:region', region);
   });
 }
 

--- a/lib/control/v1/index.js
+++ b/lib/control/v1/index.js
@@ -20,6 +20,9 @@ exports.attach = function(app, storage) {
   app.post('/v1/transit/:token/decrypt', require('./transit')(storage));
   app.use('/v1/transit', Handlers.allowed('POST'));
 
+  app.post('/v1/kms/decrypt', require('./kms')(storage));
+  app.use('/v1/kms', Handlers.allowed('POST'));
+
   app.use(Handlers.allowed('GET'));
   app.use(Err);
 };

--- a/lib/control/v1/kms.js
+++ b/lib/control/v1/kms.js
@@ -13,6 +13,8 @@ function KMS(storage) {
     storage.lookup('', req.body, KMSProvider)
       .then((result) => {
         if (result) {
+          // AWS-SDK gives out weirdly formatted keys, so make them
+          // consistent with formatting across the rest of Tokend
           Object.keys(result).forEach((key) => {
             result[key.toLowerCase()] = result[key];
             if (key.toLowerCase() !== key) {
@@ -20,6 +22,7 @@ function KMS(storage) {
             }
           });
         }
+
         // Check for both undefined and null. `!= null` handles both cases.
         if (result != null && result.hasOwnProperty('plaintext')) { // eslint-disable-line eqeqeq
           result.plaintext = Buffer.from(result.plaintext, 'base64').toString();

--- a/lib/control/v1/kms.js
+++ b/lib/control/v1/kms.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const KMSProvider = require('../../providers/kms');
+
+/**
+ * Route handler for KMS secrets
+ * @param {StorageService} storage
+ * @returns {function}
+ */
+function KMS(storage) {
+  return (req, res, next) => {
+    // KMS doesn't require a token so we can just pass an empty string
+    storage.lookup('', req.body, KMSProvider)
+      .then((result) => {
+        if (result != null) { // eslint-disable-line eqeqeq
+          Object.keys(result).forEach((key) => {
+            result[key.toLowerCase()] = result[key];
+            if (key.toLowerCase() !== key) {
+              delete result[key];
+            }
+          });
+        }
+        // Check for both undefined and null. `!= null` handles both cases.
+        if (result != null && result.hasOwnProperty('plaintext')) { // eslint-disable-line eqeqeq
+          result.plaintext = Buffer.from(result.plaintext, 'base64').toString();
+        }
+
+        if (result != null && result.hasOwnProperty('correlation_id')) { // eslint-disable-line eqeqeq
+          res.correlationId = result.correlation_id;
+          delete result.correlation_id;
+        }
+
+        res.json(result);
+      })
+      .catch(next);
+  };
+}
+
+module.exports = KMS;

--- a/lib/control/v1/kms.js
+++ b/lib/control/v1/kms.js
@@ -12,7 +12,7 @@ function KMS(storage) {
     // KMS doesn't require a token so we can just pass an empty string
     storage.lookup('', req.body, KMSProvider)
       .then((result) => {
-        if (result != null) { // eslint-disable-line eqeqeq
+        if (result) {
           Object.keys(result).forEach((key) => {
             result[key.toLowerCase()] = result[key];
             if (key.toLowerCase() !== key) {

--- a/lib/providers/credential.js
+++ b/lib/providers/credential.js
@@ -41,6 +41,11 @@ class CredentialProvider {
   invalidate() {
     this.data = null;
   }
+
+  /**
+   * Does the provider require a Vault token
+   */
+  requireVaultToken() { }
 }
 
 module.exports = CredentialProvider;

--- a/lib/providers/generic.js
+++ b/lib/providers/generic.js
@@ -84,6 +84,11 @@ class GenericProvider {
   invalidate() {
     this.data = null;
   }
+
+  /**
+   * Does the provider require a Vault token
+   */
+  requireVaultToken() { }
 }
 
 module.exports = GenericProvider;

--- a/lib/providers/kms.js
+++ b/lib/providers/kms.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const preconditions = require('conditional');
+const promisify = require('./../utils/promisify');
+const checkNotEmpty = preconditions.checkNotEmpty;
+const AWS = require('aws-sdk');
+
+/**
+ * Provider for KMS encrypted secrets
+ */
+class KMSProvider {
+    /**
+   * Create a new instance of the `KMSProvider`.
+   *
+   * @param {Object} secret
+   */
+  constructor(secret) {
+    checkNotEmpty(secret, 'secret is required');
+    checkNotEmpty(secret.ciphertext, 'secret.ciphertext is required');
+
+    this._parameters = {
+      CiphertextBlob: Buffer.from(secret.ciphertext, 'base64')
+    };
+  }
+
+  /**
+   * Initialize the credentials
+   * @returns {Promise}
+   */
+  initialize() {
+    return this._decrypt();
+  }
+
+  /**
+   * Retrieve and decrypt data from KMS
+   * @return {Promise}
+   * @private
+   */
+  _decrypt() {
+    let region = Config.get('metadata:region');
+
+    region = (typeof region === 'undefined') ? 'us-east-1' : region;
+
+    return promisify((done) => new AWS.KMS({region}).decrypt(this._parameters, done))
+      .then((data) => ({data}));
+  }
+
+  /**
+   * Removes cached data
+   *
+   * This is stubbed to conform to the Provider interface
+   */
+  invalidate() { }
+}
+
+module.exports = KMSProvider;

--- a/lib/providers/kms.js
+++ b/lib/providers/kms.js
@@ -37,7 +37,7 @@ class KMSProvider {
    * @private
    */
   _decrypt() {
-    let region = Config.get('metadata:region');
+    let region = Config.get('kms:region');
 
     region = (typeof region === 'undefined') ? 'us-east-1' : region;
 

--- a/lib/providers/kms.js
+++ b/lib/providers/kms.js
@@ -39,7 +39,9 @@ class KMSProvider {
   _decrypt() {
     let region = Config.get('kms:region');
 
-    region = (typeof region === 'undefined') ? 'us-east-1' : region;
+    if (!region) {
+      region = 'us-east-1';
+    }
 
     return promisify((done) => new AWS.KMS({region}).decrypt(this._parameters, done))
       .then((data) => ({data}));

--- a/lib/providers/token.js
+++ b/lib/providers/token.js
@@ -2,9 +2,9 @@
 
 const Vaulted = require('vaulted');
 const promisify = require('./../utils/promisify');
-const AWS = require('aws-sdk');
 const http = require('http');
 const STATUS_CODES = require('./../control/util/status-codes');
+const metadata = require('./../utils/metadata').metadata;
 const preconditions = require('conditional');
 const checkNotNull = preconditions.checkNotNull;
 
@@ -18,8 +18,6 @@ const METADATA_ENDPOINTS = [
 const DEFAULT_VAULT_PORT = Config.get('vault:port');
 const DEFAULT_VAULT_HOST = Config.get('vault:host');
 const DEFAULT_VAULT_TLS = Config.get('vault:tls');
-
-const DEFAULT_METADATA_HOST = Config.get('metadata:host');
 
 // Default Warden connection options
 const DEFAULT_WARDEN_HOST = Config.get('warden:host');
@@ -58,23 +56,9 @@ class TokenProvider {
     const opts = options || {};
 
     // Set metadata options
-    let metadata = null,
-      client = null;
+    this._metadata = metadata(opts);
 
-    if (opts.metadata) {
-      opts.metadata.host = opts.metadata.host || DEFAULT_METADATA_HOST;
-
-      metadata = opts.metadata.client;
-    } else {
-      opts.metadata = {
-        host: DEFAULT_METADATA_HOST
-      };
-    }
-    if (!!metadata && metadata instanceof AWS.MetadataService) {
-      this._metadata = metadata;
-    } else {
-      this._metadata = new AWS.MetadataService({host: opts.metadata.host});
-    }
+    let client = null;
 
     // Set Vault connection options
     const vault = {

--- a/lib/providers/token.js
+++ b/lib/providers/token.js
@@ -260,6 +260,11 @@ class TokenProvider {
       req.end();
     });
   }
+
+  /**
+   * Does the provider require a Vault token
+   */
+  requireVaultToken() { }
 }
 
 module.exports = TokenProvider;

--- a/lib/providers/transit.js
+++ b/lib/providers/transit.js
@@ -73,6 +73,10 @@ class TransitProvider {
    */
   invalidate() {}
 
+  /**
+   * Does the provider require a Vault token
+   */
+  requireVaultToken() { }
 }
 
 module.exports = TransitProvider;

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -111,8 +111,17 @@ class StorageService {
    */
   _getLeaseManager(token, secret, ProviderType) {
     const secretID = `/${ProviderType.prototype.constructor.name}/${token}/${secret}`;
+    let tokenManager;
 
-    return this.defaultToken.initialize().then(() => {
+    if (typeof ProviderType.prototype.requireVaultToken === 'function') {
+      // We need a Vault token
+      tokenManager = this.defaultToken.initialize();
+    } else {
+      // Otherwise, just resolve the object structure we're looking for with an empty string for the token
+      tokenManager = Promise.resolve({data: {token: ''}});
+    }
+
+    return tokenManager.then((data) => {
       // If the LeaseManager is already provisioned, return it
       if (this._managers.has(secretID)) {
         const manager = this._managers.get(secretID);
@@ -122,7 +131,9 @@ class StorageService {
         return manager.initialize();
       }
 
-      const manager = this._createManager(this.defaultToken.data.token, secret, ProviderType, secretID);
+      token = data.data.token;
+
+      const manager = this._createManager(token, secret, ProviderType, secretID);
 
       manager.initialize();
 

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -60,8 +60,7 @@ class StorageService {
    *
    * @param {string} token - the token to use to lookup the secret (currently a no-op)
    * @param {string} secret - the secret to lookup
-   * @param {TokenProvider|CubbyHoleProvider|SecretProvider|CredentialProvider} ProviderType - the type of provider
-   * to instantiate
+   * @param {*} ProviderType - the type of provider to instantiate
    * @returns {Promise}
    */
   lookup(token, secret, ProviderType) {
@@ -103,8 +102,7 @@ class StorageService {
    * @private
    * @param {string} token - the token to use to lookup the secret (currently a no-op)
    * @param {string} secret - the secret to get (or provision) a LeaseManager for
-   * @param {TokenProvider|CubbyHoleProvider|SecretProvider|CredentialProvider} ProviderType - the type of provider
-   * to instantiate
+   * @param {*} ProviderType - the type of provider to instantiate
    *
    * @returns {Promise<LeaseManager>}
    *
@@ -145,8 +143,7 @@ class StorageService {
    * Creates a `LeaseManager` with the given configuration options
    * @param {string} token - the token to use to lookup the secret (currently a no-op)
    * @param {string} secret - the secret to get (or provision) a LeaseManager for
-   * @param {TokenProvider|CubbyHoleProvider|SecretProvider|CredentialProvider|TransitProvider} ProviderType - the
-   * type of provider to instantiate.
+   * @param {*} ProviderType - the type of provider to instantiate
    * @param {string} secretID - the identifier to use to retrieve the `LeaseManager` from the
    * StorageService#_managers Map.
    *

--- a/lib/utils/metadata.js
+++ b/lib/utils/metadata.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const AWS = require('aws-sdk');
+const promisify = require('./../utils/promisify');
+const DEFAULT_METADATA_HOST = Config.get('metadata:host');
+
+/**
+ * Create an AWS.MetadataService client
+ * @param {Object} options
+ * @return {AWS.MetadataService}
+ */
+function getMetadata(options) {
+  const opts = options || {};
+
+  let metadata = null;
+
+  if (opts.metadata) {
+    opts.metadata.host = opts.metadata.host || DEFAULT_METADATA_HOST;
+
+    metadata = opts.metadata.client;
+  } else {
+    opts.metadata = {
+      host: DEFAULT_METADATA_HOST
+    };
+  }
+
+  if (!!metadata && metadata instanceof AWS.MetadataService) {
+    return metadata;
+  }
+
+  return new AWS.MetadataService({host: opts.metadata.host});
+}
+
+/**
+ * Get the instance's region from its metadata
+ * @param {AWS.MetadataService} [metadata]
+ * @return {Promise}
+ */
+function getRegion(metadata) {
+  let client = (metadata) ? metadata : getMetadata();
+
+  return promisify((done) => client.request('/latest/dynamic/instance-identity/document', done)).then((data) => {
+    let document = null;
+
+    try {
+      document = JSON.parse(data);
+    } catch (ex) {
+      throw ex;
+    }
+
+    return document.region;
+  });
+}
+
+module.exports = {
+  metadata: getMetadata,
+  region: getRegion
+};

--- a/lib/utils/metadata.js
+++ b/lib/utils/metadata.js
@@ -37,16 +37,10 @@ function getMetadata(options) {
  * @return {Promise}
  */
 function getRegion(metadata) {
-  let client = (metadata) ? metadata : getMetadata();
+  let client = metadata || getMetadata();
 
   return promisify((done) => client.request('/latest/dynamic/instance-identity/document', done)).then((data) => {
-    let document = null;
-
-    try {
-      document = JSON.parse(data);
-    } catch (ex) {
-      throw ex;
-    }
+    const document = JSON.parse(data);
 
     return document.region;
   });

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "yargs": "~4.7.0"
   },
   "devDependencies": {
+    "aws-sdk-mock": "^1.6.1",
     "chai": "~3.5.0",
     "chai-as-promised": "~5.3.0",
     "coveralls": "~2.11.9",

--- a/test/provider-kms.js
+++ b/test/provider-kms.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const KMSProvider = require('../lib/providers/kms');
+const AWS = require('aws-sdk-mock');
+const should = require('should');
+const preconditions = require('conditional');
+const UUID = require('node-libuuid');
+
+/**
+ * Generate an AWS-like error message for mocking bad KMS requests
+ * @param {string} type
+ * @returns {Error}
+ */
+function generateKMSError(type) {
+  const e = new Error();
+
+  e.code = type;
+  e.message = null;
+  e.name = type;
+  e.requestId = UUID.v4();
+  e.retryDelay = parseFloat(Math.min(Math.random() * 5, 5)); // Generate random num between 0 and 5 and parse as float
+  e.retryable = false;
+
+  return e;
+}
+
+describe('Provider/KMS', function() {
+  describe('KMSProvider#constructor', function() {
+    it('requires secret be provided', function() {
+      [null, undefined, ''].forEach(function(value) {
+        should.throws(() => new KMSProvider(value),
+            preconditions.IllegalValueError,
+            `invalid "secret" argument: ${value}`);
+      });
+    });
+
+    it('requires secret.ciphertext be provided', function() {
+      [null, undefined, ''].forEach(function(value) {
+        should.throws(() => new KMSProvider({key: 'KEY', ciphertext: value}),
+            preconditions.IllegalValueError,
+            `invalid "secret.ciphertext" argument: ${value}`);
+      });
+    });
+
+    describe('KMSProvider#initialize', function() {
+      const validResponse = {
+        KeyId: 'arn:aws:kms:us-east-1:ACCOUNT:key/SOME-UUID',
+        PlainText: Buffer.from('this-is-a-secret', 'utf8').toString('base64')
+      };
+
+      afterEach(function() {
+        AWS.restore();
+      });
+
+      it('returns decrypted data if the ciphertext is valid', function() {
+        AWS.mock('KMS', 'decrypt', function(params, callback) {
+          callback(null, validResponse);
+        });
+        const provider = new KMSProvider({ciphertext: 'foo'});
+
+        return provider.initialize().then((data) => {
+          data.should.have.keys('data');
+          data.data.should.have.keys(['PlainText', 'KeyId']);
+          Buffer.from(data.data.PlainText, 'base64').toString().should.equal('this-is-a-secret');
+        });
+      });
+
+      it('returns an error if the ciphertext is invalid', function() {
+        AWS.mock('KMS', 'decrypt', function(params, callback) {
+          // KMS.decrypt returns an error in the node (err, data) CB form
+          callback(generateKMSError('InvalidCiphertextException'), null);
+        });
+        const provider = new KMSProvider({ciphertext: 'foo'});
+
+        return provider.initialize().catch((err) => {
+          err.name.should.equal('InvalidCiphertextException');
+        });
+      });
+    });
+    //InvalidCiphertextException
+  });
+});

--- a/test/storage-service.js
+++ b/test/storage-service.js
@@ -29,6 +29,7 @@ class ImmediateInitializeProvider {
       }
     });
   }
+  requireVaultToken() { }
 }
 
 class MockTokenProvider {
@@ -88,6 +89,7 @@ class MockSecretProvider {
   }
 
   renew() {}
+  requireVaultToken() { }
 }
 
 class DelayedInitializeProvider {
@@ -109,6 +111,7 @@ class DelayedInitializeProvider {
       plaintext: 'SECRET'
     }});
   }
+  requireVaultToken() { }
 }
 
 class NeverInitializeProvider {
@@ -117,6 +120,7 @@ class NeverInitializeProvider {
   }
 
   renew() {}
+  requireVaultToken() { }
 }
 
 class NonRenewingProvider {
@@ -126,6 +130,7 @@ class NonRenewingProvider {
       data: {plaintext: 'PTEXT'}
     });
   }
+  requireVaultToken() { }
 }
 
 class DelayedNonRenewingProvider {
@@ -139,6 +144,7 @@ class DelayedNonRenewingProvider {
       }, 200);
     });
   }
+  requireVaultToken() { }
 }
 
 function setTokenProvider(storage, provider) {


### PR DESCRIPTION
This PR implements a `KMSProvider` (#96) and wires it up. Currently, config validation requires connection info for Vault and Warden which doesn't apply if the user is only using KMS. This is addressed by #98.