### PR TITLE
Feature: Add KMS data key decryption

### DIFF
--- a/lib/providers/kms.js
+++ b/lib/providers/kms.js
@@ -3,6 +3,7 @@
 const preconditions = require('conditional');
 const promisify = require('./../utils/promisify');
 const checkNotEmpty = preconditions.checkNotEmpty;
+const crypto = require('crypto');
 const AWS = require('aws-sdk');
 
 /**
@@ -20,19 +21,23 @@ class KMSProvider {
 
     let region = 'us-east-1';
 
-
     if (secret.region && secret.region !== '') { // eslint-disable-line eqeqeq
       region = secret.region;
     } else if (Config.get('kms:region') && Config.get('kms:region') !== '') {
       region = Config.get('kms:region');
     }
 
-
     this._parameters = {
       CiphertextBlob: Buffer.from(secret.ciphertext, 'base64')
     };
 
+    if (secret.datakey) {
+      this._datakey = true;
+      this._parameters.CiphertextBlob = Buffer.from(secret.datakey, 'base64');
+    }
+
     this._client = new AWS.KMS({region});
+    this.payload = secret;
   }
 
 
@@ -41,7 +46,25 @@ class KMSProvider {
    * @returns {Promise}
    */
   initialize() {
-    return this._decrypt();
+    const decrypt = this._decrypt();
+
+    if (!this._datakey) {
+      return decrypt;
+    }
+
+    return decrypt.then((data) => {
+      const decipher = crypto.createDecipher('aes-256-cbc', data.data.Plaintext);
+
+      // Delete the plaintext datakey from memory once we create a decipher object
+      delete data.data.Plaintext;
+
+      let decryptedPlaintext = decipher.update(this.payload.ciphertext, 'base64', 'base64');
+
+      decryptedPlaintext += decipher.final('base64');
+      data.data.Plaintext = decryptedPlaintext;
+
+      return data;
+    });
   }
 
   /**


### PR DESCRIPTION
This PR adds decryption support for secrets encrypted against data keys generated via [`KMS. generateDataKey()`](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/KMS.html#generateDataKey-property). The initial implementation requires all secrets to be encrypted via the `aes-256-cbc` cipher.