### PR TITLE
Cookbook: Specify package version

### DIFF
--- a/cookbook/recipes/default.rb
+++ b/cookbook/recipes/default.rb
@@ -36,6 +36,7 @@ version_dir = "#{ node['tokend']['paths']['directory'] }-#{ node['tokend']['vers
 package 'tokend' do
   source resources('remote_file[tokend]').path
   provider Chef::Provider::Package::Dpkg
+  version node['tokend']['version']
 end
 
 ## Symlink the version dir to the specified tokend directory


### PR DESCRIPTION
This PR specifies the package version to install.

It resolves a subtle issue in the upgrade behavior of the `package` resource. Even though the default action of the `dpkg_package` resource calls `dpkg -i` (which doesn't have an upgrade mechanism), the logic around determining whether the `package` resource should actually call the `dpkg_resource` to upgrade checks whether the cached version is the same as the version to be installed.