### PR TITLE
Cookbook: Guard symlink resource

### DIFF
--- a/cookbook/metadata.rb
+++ b/cookbook/metadata.rb
@@ -16,3 +16,4 @@ long_description IO.read(::File.join(project_path, 'README.md')) rescue ''
 version package_dot_json.fetch('version', '0.0.1')
 
 depends 'nodejs'
+depends 'ark', '~> 3.0.0'

--- a/cookbook/recipes/default.rb
+++ b/cookbook/recipes/default.rb
@@ -37,11 +37,15 @@ package 'tokend' do
   source resources('remote_file[tokend]').path
   provider Chef::Provider::Package::Dpkg
   version node['tokend']['version']
+
+  notifies :create, "link[#{node['tokend']['paths']['directory']}]", :immediately
 end
 
 ## Symlink the version dir to the specified tokend directory
 link node['tokend']['paths']['directory'] do
   to version_dir
+
+  action :nothing
   notifies :restart, 'service[tokend]' if node['tokend']['enable']
 end
 


### PR DESCRIPTION
This PR adds a notification guard to the symlink resource so nothing gets linked unless the service is installed.