### PR TITLE
Use request promise

### DIFF
--- a/lib/providers/token.js
+++ b/lib/providers/token.js
@@ -2,8 +2,7 @@
 
 const Vault = require('node-vault');
 const promisify = require('./../utils/promisify');
-const http = require('http');
-const STATUS_CODES = require('./../control/util/status-codes');
+const rp = require('request-promise-native');
 const metadata = require('./../utils/metadata').metadata;
 const preconditions = require('conditional');
 const checkNotNull = preconditions.checkNotNull;
@@ -74,8 +73,6 @@ class TokenProvider {
 
     // Set Warden connection options
     this._warden = {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
       hostname: DEFAULT_WARDEN_HOST,
       port: DEFAULT_WARDEN_PORT,
       path: DEFAULT_WARDEN_PATH
@@ -85,6 +82,9 @@ class TokenProvider {
       this._warden.hostname = opts.warden.host;
       this._warden.port = opts.warden.port;
     }
+
+    this._warden.uri = `http://${this._warden.hostname}:${this._warden.port}${this._warden.path}`;
+    ['port', 'hostname', 'path'].forEach((p) => delete this._warden[p]);
 
     this.token = null;
     this.data = null;
@@ -187,10 +187,15 @@ class TokenProvider {
    * @private
    */
   _sendDocument(data) {
-    return this._post({
-      document: data[0],
-      signature: `-----BEGIN PKCS7-----\n${data[2]}\n-----END PKCS7-----\n`
-    });
+    return rp(Object.assign({}, this._warden, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: {
+        document: data[0],
+        signature: `-----BEGIN PKCS7-----\n${data[2]}\n-----END PKCS7-----\n`
+      },
+      json: true
+    }));
   }
 
   /**
@@ -202,53 +207,6 @@ class TokenProvider {
     return Promise.all(METADATA_ENDPOINTS.map((path) => { // eslint-disable-line arrow-body-style
       return promisify((done) => this._metadata.request(path, done));
     }));
-  }
-
-  /**
-   * Sends the POST request wrapped in a Promise
-   * @param {object} payload
-   * @returns {Promise}
-   * @private
-   */
-  _post(payload) {
-    const payloadStr = JSON.stringify(payload);
-
-    this._warden.headers['Content-Length'] = payloadStr.length;
-
-    return new Promise((resolve, reject) => {
-      const req = http.request(this._warden, (res) => {
-        let body = '';
-
-        res.setEncoding('utf8');
-        res.on('data', (chunk) => body += chunk);
-        res.on('end', (chunk) => {
-          if (chunk) {
-            body += chunk;
-          }
-
-          if (res.statusCode !== STATUS_CODES.OK) {
-            reject(new Error(`${res.statusCode}: ${body}`));
-
-            return;
-          }
-
-          let parsedBody;
-
-          try {
-            parsedBody = JSON.parse(body);
-          } catch (ex) {
-            req.emit('error', ex);
-
-            return;
-          }
-
-          resolve(parsedBody);
-        });
-      }).on('error', (err) => reject(err));
-
-      req.write(payloadStr);
-      req.end();
-    });
   }
 
   /**

--- a/lib/storage-service.js
+++ b/lib/storage-service.js
@@ -31,6 +31,7 @@ class StorageService {
 
   /**
    * Getter for the default token
+   * @return {LeaseManager}
    */
   get defaultToken() {
     const tokenManagerID = '/TokenProvider/default/default';

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "morgan": "~1.7.0",
     "nconf": "~0.8.4",
     "node-vault": "^0.5.10",
+    "request": "^2.81.0",
+    "request-promise-native": "^1.0.4",
     "uuid": "~3.0.1",
     "winston": "~2.2.0",
     "yargs": "~4.7.0"

--- a/test/init.js
+++ b/test/init.js
@@ -13,7 +13,8 @@ const defaults = Object.assign(require('../config/defaults.json'), {
   },
   warden: {
     host: '127.0.0.1',
-    port: 3000
+    port: 3000,
+    path: '/'
   }
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,7 +31,7 @@ ajv-keywords@^1.0.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
 
-ajv@^4.7.0:
+ajv@^4.7.0, ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
   dependencies:
@@ -253,6 +253,10 @@ camelcase@^3.0.0:
 caseless@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
+
+caseless@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
 catharsis@~0.8.8:
   version "0.8.8"
@@ -999,6 +1003,10 @@ handlebars@^4.0.1:
   optionalDependencies:
     uglify-js "^2.6"
 
+har-schema@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
+
 har-validator@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-2.0.6.tgz#cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d"
@@ -1007,6 +1015,13 @@ har-validator@~2.0.6:
     commander "^2.9.0"
     is-my-json-valid "^2.12.4"
     pinkie-promise "^2.0.0"
+
+har-validator@~4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
+  dependencies:
+    ajv "^4.9.1"
+    har-schema "^1.0.5"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -1443,6 +1458,10 @@ lodash@^4.0.0, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.8.2, lodash@~4.13.0:
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.13.1.tgz#83e4b10913f48496d4d16fec4a560af2ee744b68"
 
+lodash@^4.13.1:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
 lodash@~3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.5.0.tgz#19bb3f4d51278f0b8c818ed145c74ecf9fe40e6d"
@@ -1726,6 +1745,10 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+performance-now@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
+
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -1816,6 +1839,10 @@ qs@^6.1.0, qs@~6.3.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
 
+qs@~6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
 range-parser@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.0.3.tgz#6872823535c692e2c2a0103826afd82c2e0ff175"
@@ -1873,6 +1900,20 @@ repeat-string@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
+request-promise-core@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
+  dependencies:
+    lodash "^4.13.1"
+
+request-promise-native@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.4.tgz#86988ec8eee408e45579fce83bfd05b3adf9a155"
+  dependencies:
+    request-promise-core "1.1.1"
+    stealthy-require "^1.1.0"
+    tough-cookie ">=2.3.0"
+
 request-promise@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-2.0.1.tgz#acbd47b725e39372ede3174cf29c38d9ecf2b30d"
@@ -1904,6 +1945,33 @@ request@2.79.0, request@^2.34:
     stringstream "~0.0.4"
     tough-cookie "~2.3.0"
     tunnel-agent "~0.4.1"
+    uuid "^3.0.0"
+
+request@^2.81.0:
+  version "2.81.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
+  dependencies:
+    aws-sign2 "~0.6.0"
+    aws4 "^1.2.1"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.0"
+    forever-agent "~0.6.1"
+    form-data "~2.1.1"
+    har-validator "~4.2.1"
+    hawk "~3.1.3"
+    http-signature "~1.1.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.7"
+    oauth-sign "~0.8.1"
+    performance-now "^0.2.0"
+    qs "~6.4.0"
+    safe-buffer "^5.0.1"
+    stringstream "~0.0.4"
+    tough-cookie "~2.3.0"
+    tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
 require-main-filename@^1.0.1:
@@ -1959,6 +2027,10 @@ run-async@^0.1.0:
 rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
+
+safe-buffer@^5.0.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
 samsam@1.1.2, samsam@~1.1:
   version "1.1.2"
@@ -2142,6 +2214,10 @@ statuses@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.2.1.tgz#dded45cc18256d51ed40aec142489d5c61026d28"
 
+stealthy-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -2260,7 +2336,7 @@ through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
-tough-cookie@~2.3.0:
+tough-cookie@>=2.3.0, tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
   dependencies:
@@ -2273,6 +2349,12 @@ traverse@^0.6.6:
 tryit@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  dependencies:
+    safe-buffer "^5.0.1"
 
 tunnel-agent@~0.4.1:
   version "0.4.3"


### PR DESCRIPTION
This PR adds `request-promise-native` as a drop-in replacement for our custom wrap-a-http-request-in-a-promise implementation. This allows us to be a bit more terse in our code and allow `rp` to smooth out our edge cases.