### PR TITLE
Make storage service timeout tunable

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -72,7 +72,9 @@ app.use(BodyParser.json());
 
 const StorageService = require('../lib/storage-service');
 
-const storage = new StorageService();
+const storage = new StorageService({
+  timeout: Config.get('service:storage:timeout')
+});
 
 require('../lib/control/v1').attach(app, storage);
 

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -7,7 +7,10 @@
   },
   "service": {
     "host": "127.0.0.1",
-    "port": 4500
+    "port": 4500,
+    "storage": {
+      "timeout": 500
+    }
   },
   "log": {
     "level": "INFO",

--- a/config/dev.json
+++ b/config/dev.json
@@ -8,6 +8,11 @@
   "metadata": {
     "host": "127.0.0.1:8900"
   },
+  "service": {
+    "storage": {
+      "timeout": 5000
+    }
+  },
   "warden": {
     "host": "127.0.0.1"
   },


### PR DESCRIPTION
We noticed an issue where cross-region decryption can result in `onceWithTimeout` failing before the aws-sdk is able to complete its decryption process. This PR allows us to tune the timeout accordingly.