### PR TITLE
Remove kms dependency on storage service

### DIFF
--- a/lib/control/v1/index.js
+++ b/lib/control/v1/index.js
@@ -20,7 +20,7 @@ exports.attach = function(app, storage) {
   app.post('/v1/transit/:token/decrypt', require('./transit')(storage));
   app.use('/v1/transit', Handlers.allowed('POST'));
 
-  app.post('/v1/kms/decrypt', require('./kms')(storage));
+  app.post('/v1/kms/decrypt', require('./kms')());
   app.use('/v1/kms', Handlers.allowed('POST'));
 
   app.use(Handlers.allowed('GET'));

--- a/lib/control/v1/kms.js
+++ b/lib/control/v1/kms.js
@@ -24,7 +24,7 @@ function KMS() {
     (new KMSProvider(req.body)).initialize().then((result) => {
       // I don't know how we'd get a falsy `result` but we need a method for handling it
       if (!result) {
-        return;
+        return res.json(result);
       }
 
       let data = {};

--- a/lib/control/v1/kms.js
+++ b/lib/control/v1/kms.js
@@ -29,12 +29,12 @@ function KMS() {
 
       let data = {};
 
-      // Handle a case where there's no
+      // Handle a case where the result set has a nested data object
       if (result.hasOwnProperty('data')) {
         data = normalizeKeys(result.data);
       }
 
-      // Check for both undefined and null. `!= null` handles both cases.
+      // If the data returned has a plaintext property convert it from base64
       if (data.hasOwnProperty('plaintext')) { // eslint-disable-line eqeqeq
         data.plaintext = Buffer.from(data.plaintext, 'base64').toString();
       }

--- a/lib/control/v1/kms.js
+++ b/lib/control/v1/kms.js
@@ -3,39 +3,45 @@
 const KMSProvider = require('../../providers/kms');
 
 /**
+ * AWS-SDK gives out weirdly formatted keys, so make them
+ * consistent with formatting across the rest of Tokend
+ *
+ * @param obj
+ * @returns {Object}
+ */
+const normalizeKeys = (obj) => Object.keys(obj).reduce((acc, key) => {
+  acc[key.toLowerCase()] = obj[key];
+
+  return acc;
+}, {});
+
+/**
  * Route handler for KMS secrets
  * @param {StorageService} storage
  * @returns {function}
  */
 function KMS(storage) {
   return (req, res, next) => {
-    // KMS doesn't require a token so we can just pass an empty string
-    storage.lookup('', req.body, KMSProvider)
-      .then((result) => {
-        if (result) {
-          // AWS-SDK gives out weirdly formatted keys, so make them
-          // consistent with formatting across the rest of Tokend
-          Object.keys(result).forEach((key) => {
-            result[key.toLowerCase()] = result[key];
-            if (key.toLowerCase() !== key) {
-              delete result[key];
-            }
-          });
-        }
+    (new KMSProvider(req.body)).initialize().then((result) => {
+      // I don't know how we'd get a falsy `result` but we need a method for handling it
+      if (!result) {
+        return;
+      }
 
-        // Check for both undefined and null. `!= null` handles both cases.
-        if (result != null && result.hasOwnProperty('plaintext')) { // eslint-disable-line eqeqeq
-          result.plaintext = Buffer.from(result.plaintext, 'base64').toString();
-        }
+      let data = {};
 
-        if (result != null && result.hasOwnProperty('correlation_id')) { // eslint-disable-line eqeqeq
-          res.correlationId = result.correlation_id;
-          delete result.correlation_id;
-        }
+      // Handle a case where there's no
+      if (result.hasOwnProperty('data')) {
+        data = normalizeKeys(result.data);
+      }
 
-        res.json(result);
-      })
-      .catch(next);
+      // Check for both undefined and null. `!= null` handles both cases.
+      if (data.hasOwnProperty('plaintext')) { // eslint-disable-line eqeqeq
+        data.plaintext = Buffer.from(data.plaintext, 'base64').toString();
+      }
+
+      res.json(data);
+    }).catch(next);
   };
 }
 

--- a/lib/control/v1/kms.js
+++ b/lib/control/v1/kms.js
@@ -6,7 +6,7 @@ const KMSProvider = require('../../providers/kms');
  * AWS-SDK gives out weirdly formatted keys, so make them
  * consistent with formatting across the rest of Tokend
  *
- * @param obj
+ * @param {Object} obj
  * @returns {Object}
  */
 const normalizeKeys = (obj) => Object.keys(obj).reduce((acc, key) => {

--- a/lib/control/v1/kms.js
+++ b/lib/control/v1/kms.js
@@ -17,10 +17,9 @@ const normalizeKeys = (obj) => Object.keys(obj).reduce((acc, key) => {
 
 /**
  * Route handler for KMS secrets
- * @param {StorageService} storage
  * @returns {function}
  */
-function KMS(storage) {
+function KMS() {
   return (req, res, next) => {
     (new KMSProvider(req.body)).initialize().then((result) => {
       // I don't know how we'd get a falsy `result` but we need a method for handling it


### PR DESCRIPTION
This PR attempts to address issues with timeouts where `onceWithTimeout` obscures the real errors that are occurring, rendering debugging almost impossible. 

To do this, the PR removes the `/v1/kms/decrypt` endpoint handler's dependency on `StorageService`. In reality, the `KMSProvider` doesn't actually need the `StorageService` and `LeaseManager` as its behavior is transactional (one request == one call to the KMS API) and doesn't rely on any of the built in token management stuff that `StorageService` and `LeaseManager` are responsible for.