### PR TITLE
Updates lodash to 4.17.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "conditional": "~5.3.0",
     "express": "~4.13.4",
     "express-winston": "~2.1.0",
-    "lodash": "~4.13.0",
+    "lodash": "~4.17.5",
     "morgan": "~1.7.0",
     "nconf": "~0.8.4",
     "node-vault": "^0.5.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,7 +1454,7 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash@^4.0.0, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.8.2, lodash@~4.13.0:
+lodash@^4.0.0, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.8.2:
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.13.1.tgz#83e4b10913f48496d4d16fec4a560af2ee744b68"
 
@@ -1469,6 +1469,10 @@ lodash@~3.5.0:
 lodash@~4.11.1:
   version "4.11.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.11.2.tgz#d6b4338b110a58e21dae5cebcfdbbfd2bc4cdb3b"
+
+lodash@~4.17.5:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 log-driver@1.2.5:
   version "1.2.5"


### PR DESCRIPTION
Addresses https://nvd.nist.gov/vuln/detail/CVE-2018-3721